### PR TITLE
Make cloneable each structure

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -21,6 +21,7 @@ pub struct Vegalite {
     /// Setting the `$schema` property allows automatic validation and autocomplete in editors
     /// that support JSON schema.
     #[serde(rename = "$schema")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
     /// Sets how the visualization size should be determined. If a string, should be one of
     /// `"pad"`, `"fit"` or `"none"`.
@@ -29,26 +30,33 @@ pub struct Vegalite {
     /// `"fit"` is only supported for single and layered views that don't use `rangeStep`.
     ///
     /// __Default value__: `pad`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autosize: Option<Autosize>,
     /// CSS color property to use as the background of visualization.
     ///
     /// __Default value:__ none (transparent)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub background: Option<String>,
     /// Vega-Lite configuration object.  This property can only be defined at the top-level of a
     /// specification.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<Config>,
     /// An object describing the data source
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Data>,
     /// A global data store for named datasets. This is a mapping from names to inline datasets.
     /// This can be an array of objects or primitive values or a string. Arrays of primitive
     /// values are ingested as objects with a `data` property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub datasets: Option<HashMap<String, InlineDatasetValue>>,
     /// Description of this mark for commenting purpose.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// A key-value mapping between encoding channels and definition of fields.
     ///
     /// A shared key-value mapping between encoding channels and definition of fields in the
     /// underlying layers.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<Encoding>,
     /// The height of a visualization.
     ///
@@ -73,13 +81,16 @@ pub struct Vegalite {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<f64>,
     /// A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
     /// `"line"`,
     /// `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition
     /// object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<AnyMark>,
     /// Name of the visualization for later reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// The default visualization padding, in pixels, from the edge of the visualization canvas
     /// to the data rectangle.  If a number, specifies padding for all sides.
@@ -87,22 +98,28 @@ pub struct Vegalite {
     /// "bottom": 5}` to specify padding for each side of the visualization.
     ///
     /// __Default value__: `5`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding: Option<Padding>,
     /// An object defining properties of geographic projection, which will be applied to `shape`
     /// path for `"geoshape"` marks
     /// and to `latitude` and `"longitude"` channels for other marks.
     ///
     /// An object defining properties of the geographic projection shared by underlying layers.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projection: Option<Projection>,
     /// A key-value mapping between selection names and definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<HashMap<String, SelectionDef>>,
     /// Title for the plot.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
     /// An array of data transformations such as filter and new field calculation.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transform: Option<Vec<Transform>>,
     /// Optional metadata that will be passed to Vega.
     /// This object is completely ignored by Vega and Vega-Lite and can be used for custom
     /// metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub usermeta: Option<HashMap<String, Option<serde_json::Value>>>,
     /// The width of a visualization.
     ///
@@ -130,6 +147,7 @@ pub struct Vegalite {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<f64>,
     /// The alignment to apply to grid rows and columns.
     /// The supported string values are `"all"`, `"each"`, and `"none"`.
@@ -146,6 +164,7 @@ pub struct Vegalite {
     /// used to supply different alignments for rows and columns.
     ///
     /// __Default value:__ `"all"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<AlignUnion>,
     /// The bounds calculation method to use for determining the extent of a sub-plot. One of
     /// `full` (the default) or `flush`.
@@ -157,6 +176,7 @@ pub struct Vegalite {
     /// or legends into a uniform grid structure.
     ///
     /// __Default value:__ `"full"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Bounds>,
     /// Boolean flag indicating if subviews should be centered relative to their respective rows
     /// or columns.
@@ -170,9 +190,11 @@ pub struct Vegalite {
     /// or columns.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub center: Option<Center>,
     /// An object that describes mappings between `row` and `column` channels and their field
     /// definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub facet: Option<FacetMapping>,
     /// Scale, axis, and legend resolutions for facets.
     ///
@@ -183,6 +205,7 @@ pub struct Vegalite {
     /// Scale, axis, and legend resolutions for vertically concatenated charts.
     ///
     /// Scale, axis, and legend resolutions for horizontally concatenated charts.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Resolve>,
     /// The spacing in pixels between sub-views of the composition operator.
     /// An object of the form `{"row": number, "column": number}` can be used to set
@@ -193,8 +216,10 @@ pub struct Vegalite {
     /// The spacing in pixels between sub-views of the concat operator.
     ///
     /// __Default value__: `10`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spacing: Option<Spacing>,
     /// A specification of the view that gets faceted.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<SpecClass>,
     /// Layer or single view specifications to be layered.
     ///
@@ -202,13 +227,17 @@ pub struct Vegalite {
     /// layering facet specifications is not allowed. Instead, use the [facet
     /// operator](https://vega.github.io/vega-lite/docs/facet.html) and place a layer inside a
     /// facet.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub layer: Option<Vec<LayerSpec>>,
     /// An object that describes what fields should be repeated into views that are laid out as a
     /// `row` or `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub repeat: Option<Repeat>,
     /// A list of views that should be concatenated and put into a column.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vconcat: Option<Vec<Spec>>,
     /// A list of views that should be concatenated and put into a row.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hconcat: Option<Vec<Spec>>,
 }
 
@@ -227,11 +256,13 @@ pub struct AutoSizeParams {
     /// width and height settings indicate the **total** intended size of the view.
     ///
     /// __Default value__: `"content"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub contains: Option<Contains>,
     /// A boolean flag indicating if autosize layout should be re-calculated on every view
     /// update.
     ///
     /// __Default value__: `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resize: Option<bool>,
     /// The sizing format type. One of `"pad"`, `"fit"` or `"none"`. See the [autosize
     /// type](https://vega.github.io/vega-lite/docs/size.html#autosize) documentation for
@@ -239,12 +270,15 @@ pub struct AutoSizeParams {
     ///
     /// __Default value__: `"pad"`
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_size_params_type: Option<AutosizeType>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RowColBoolean {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<bool>,
 }
 
@@ -253,6 +287,7 @@ pub struct RowColBoolean {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
     /// Area-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub area: Option<AreaConfig>,
     /// Sets how the visualization size should be determined. If a string, should be one of
     /// `"pad"`, `"fit"` or `"none"`.
@@ -261,51 +296,67 @@ pub struct Config {
     /// `"fit"` is only supported for single and layered views that don't use `rangeStep`.
     ///
     /// __Default value__: `pad`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autosize: Option<Autosize>,
     /// Axis configuration, which determines default properties for all `x` and `y`
     /// [axes](https://vega.github.io/vega-lite/docs/axis.html). For a full list of axis
     /// configuration options, please see the [corresponding section of the axis
     /// documentation](https://vega.github.io/vega-lite/docs/axis.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis: Option<AxisConfig>,
     /// Specific axis config for axes with "band" scales.
     #[serde(rename = "axisBand")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_band: Option<AxisConfig>,
     /// Specific axis config for x-axis along the bottom edge of the chart.
     #[serde(rename = "axisBottom")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_bottom: Option<AxisConfig>,
     /// Specific axis config for y-axis along the left edge of the chart.
     #[serde(rename = "axisLeft")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_left: Option<AxisConfig>,
     /// Specific axis config for y-axis along the right edge of the chart.
     #[serde(rename = "axisRight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_right: Option<AxisConfig>,
     /// Specific axis config for x-axis along the top edge of the chart.
     #[serde(rename = "axisTop")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_top: Option<AxisConfig>,
     /// X-axis specific config.
     #[serde(rename = "axisX")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_x: Option<AxisConfig>,
     /// Y-axis specific config.
     #[serde(rename = "axisY")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis_y: Option<AxisConfig>,
     /// CSS color property to use as the background of visualization.
     ///
     /// __Default value:__ none (transparent)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub background: Option<String>,
     /// Bar-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bar: Option<BarConfig>,
     /// Box Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub boxplot: Option<BoxPlotConfig>,
     /// Circle-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub circle: Option<MarkConfig>,
     /// Default axis and legend title for count fields.
     ///
     /// __Default value:__ `'Number of Records'`.
     #[serde(rename = "countTitle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub count_title: Option<String>,
     /// ErrorBand Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub errorband: Option<ErrorBandConfig>,
     /// ErrorBar Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub errorbar: Option<ErrorBarConfig>,
     /// Defines how Vega-Lite generates title for fields.  There are three possible styles:
     /// - `"verbal"` (Default) - displays function in a verbal style (e.g., "Sum of field",
@@ -315,13 +366,16 @@ pub struct Config {
     /// - `"plain"` - displays only the field name without functions (e.g., "field", "date",
     /// "field").
     #[serde(rename = "fieldTitle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field_title: Option<FieldTitle>,
     /// Geoshape-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub geoshape: Option<MarkConfig>,
     /// Header configuration, which determines default properties for all
     /// [header](https://vega.github.io/vega-lite/docs/header.html). For a full list of header
     /// configuration options, please see the [corresponding section of in the header
     /// documentation](https://vega.github.io/vega-lite/docs/header.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub header: Option<HeaderConfig>,
     /// Defines how Vega-Lite should handle invalid values (`null` and `NaN`).
     /// - If set to `"filter"` (default), all data items with null values will be skipped (for
@@ -329,19 +383,24 @@ pub struct Config {
     /// - If `null`, all data items are included. In this case, invalid values will be
     /// interpreted as zeroes.
     #[serde(rename = "invalidValues")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub invalid_values: Option<InvalidValues>,
     /// Legend configuration, which determines default properties for all
     /// [legends](https://vega.github.io/vega-lite/docs/legend.html). For a full list of legend
     /// configuration options, please see the [corresponding section of in the legend
     /// documentation](https://vega.github.io/vega-lite/docs/legend.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub legend: Option<LegendConfig>,
     /// Line-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub line: Option<LineConfig>,
     /// Mark Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<MarkConfig>,
     /// D3 Number format for guide labels and text marks. For example "s" for SI units. Use [D3's
     /// number format pattern](https://github.com/d3/d3-format#locale_format).
     #[serde(rename = "numberFormat")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub number_format: Option<String>,
     /// The default visualization padding, in pixels, from the edge of the visualization canvas
     /// to the data rectangle.  If a number, specifies padding for all sides.
@@ -349,42 +408,55 @@ pub struct Config {
     /// "bottom": 5}` to specify padding for each side of the visualization.
     ///
     /// __Default value__: `5`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding: Option<Padding>,
     /// Point-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub point: Option<MarkConfig>,
     /// Projection configuration, which determines default properties for all
     /// [projections](https://vega.github.io/vega-lite/docs/projection.html). For a full list of
     /// projection configuration options, please see the [corresponding section of the projection
     /// documentation](https://vega.github.io/vega-lite/docs/projection.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projection: Option<Projection>,
     /// An object hash that defines default range arrays or schemes for using with scales.
     /// For a full list of scale range configuration options, please see the [corresponding
     /// section of the scale
     /// documentation](https://vega.github.io/vega-lite/docs/scale.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub range: Option<HashMap<String, RangeValue>>,
     /// Rect-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rect: Option<MarkConfig>,
     /// Rule-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rule: Option<MarkConfig>,
     /// Scale configuration determines default properties for all
     /// [scales](https://vega.github.io/vega-lite/docs/scale.html). For a full list of scale
     /// configuration options, please see the [corresponding section of the scale
     /// documentation](https://vega.github.io/vega-lite/docs/scale.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<ScaleConfig>,
     /// An object hash for defining default properties for each type of selections.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<SelectionConfig>,
     /// Square-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub square: Option<MarkConfig>,
     /// Default stack offset for stackable mark.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stack: Option<StackOffset>,
     /// An object hash that defines key-value mappings to determine default properties for marks
     /// with a given [style](https://vega.github.io/vega-lite/docs/mark.html#mark-def).  The keys
     /// represent styles names; the values have to be valid [mark configuration
     /// objects](https://vega.github.io/vega-lite/docs/mark.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<HashMap<String, VgMarkConfig>>,
     /// Text-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextConfig>,
     /// Tick-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick: Option<TickConfig>,
     /// Default time format for raw time values (without time units) in text marks, legend labels
     /// and header labels.
@@ -393,16 +465,20 @@ pub struct Config {
     /// __Note:__ Axes automatically determine format each label automatically so this config
     /// would not affect axes.
     #[serde(rename = "timeFormat")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_format: Option<String>,
     /// Title configuration, which determines default properties for all
     /// [titles](https://vega.github.io/vega-lite/docs/title.html). For a full list of title
     /// configuration options, please see the [corresponding section of the title
     /// documentation](https://vega.github.io/vega-lite/docs/title.html#config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<VgTitleConfig>,
     /// Trail-Specific Config
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub trail: Option<LineConfig>,
     /// Default properties for [single view
     /// plots](https://vega.github.io/vega-lite/docs/spec.html#single).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub view: Option<ViewConfig>,
 }
 
@@ -1308,12 +1384,15 @@ pub struct BoxPlotConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MarkConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The rotation angle of the text, in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
     ///
     /// __Default value:__ `"middle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Default color.  Note that `fill` and `stroke` have higher precedence than `color` and
     /// will override `color`.
@@ -1322,33 +1401,41 @@ pub struct MarkConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// The radius in pixels of rounded rectangle corners.
     ///
     /// __Default value:__ `0`
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The mouse cursor used over the mark. Any valid [CSS cursor
     /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
     /// The direction of the text. One of `"ltr"` (left-to-right) or `"rtl"` (right-to-left).
     /// This property determines on which side is truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"ltr"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dir: Option<Dir>,
     /// The horizontal offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dx: Option<f64>,
     /// The vertical offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dy: Option<f64>,
     /// The ellipsis string for text truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"…"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ellipsis: Option<String>,
     /// Default Fill Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// Whether the mark's color should be used as fill color instead of stroke color.
     ///
@@ -1358,26 +1445,33 @@ pub struct MarkConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filled: Option<bool>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The typeface to set the text in (e.g., `"Helvetica Neue"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// The font size, in pixels.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// The font style (e.g., `"italic"`).
     #[serde(rename = "fontStyle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<FontStyle>,
     /// The font weight.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// The line interpolation method to use for line and area marks. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -1397,16 +1491,19 @@ pub struct MarkConfig {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The maximum length of the text mark in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The overall opacity (value between [0,1]).
     ///
     /// __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or
     /// `square` marks or layered `bar` charts and `1` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f64>,
     /// The orientation of a non-stacked bar, tick, area, and line charts.
     /// The value is either horizontal (default) or vertical.
@@ -1418,14 +1515,17 @@ pub struct MarkConfig {
     /// if `config.sortLineBy` is not specified.
     /// For stacked charts, this is always determined by the orientation of the stack;
     /// therefore explicitly specified value will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<Orient>,
     /// Polar coordinate radial offset, in pixels, of the text label from the origin determined
     /// by the `x` and `y` properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
     /// The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`,
     /// `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
     ///
     /// __Default value:__ `"circle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
     /// Default size for marks.
     /// - For `point`/`circle`/`square`, this represents the pixel area of the marks. For
@@ -1437,46 +1537,58 @@ pub struct MarkConfig {
     /// __Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks
     /// with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text
     /// marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
     /// Default Stroke Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
     ///
     /// __Default value:__ `"square"`
     #[serde(rename = "strokeCap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_cap: Option<StrokeCap>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of `"miter"`, `"round"` or `"bevel"`.
     ///
     /// __Default value:__ `"miter"`
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The miter limit at which to bevel a line join.
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// Depending on the interpolation type, sets the tension parameter (for line and area marks).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
     /// Placeholder text if the `text` channel is not specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// Polar coordinate angle, in radians, of the text label from the origin determined by the
     /// `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark
     /// `startAngle` and `endAngle` properties: angles are measured in radians, with `0`
     /// indicating "north".
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub theta: Option<f64>,
     /// The tooltip text string to show upon mouse hover or an object defining which fields
     /// should the tooltip be derived from.
@@ -1485,13 +1597,16 @@ pub struct MarkConfig {
     /// used.
     /// - If `tooltip` is `{"content": "data"}`, then all fields that appear in the highlighted
     /// data point will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<Tooltip>,
 }
 
 /// ErrorBand Config
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorBandConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub band: Option<BooleanOrMarkConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub borders: Option<BooleanOrMarkConfig>,
     /// The extent of the band. Available options include:
     /// - `"ci"`: Extend the band to the confidence interval of the mean.
@@ -1502,6 +1617,7 @@ pub struct ErrorBandConfig {
     /// - `"iqr"`: Extend the band to the q1 and q3.
     ///
     /// __Default value:__ `"stderr"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<ErrorbandExtent>,
     /// The line interpolation method for the error band. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -1521,8 +1637,10 @@ pub struct ErrorBandConfig {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The tension parameter for the interpolation type of the error band.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
 }
 
@@ -1538,8 +1656,11 @@ pub struct ErrorBarConfig {
     /// - `"iqr"`: Extend the rule to the q1 and q3.
     ///
     /// __Default value:__ `"stderr"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<ErrorbandExtent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rule: Option<BooleanOrMarkConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ticks: Option<BooleanOrMarkConfig>,
 }
 
@@ -1553,27 +1674,33 @@ pub struct HeaderConfig {
     ///
     /// __Default value:__ `0` for column header, `-90` for row header.
     #[serde(rename = "labelAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_angle: Option<f64>,
     /// The color of the header label, can be in hex color code or regular color name.
     #[serde(rename = "labelColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_color: Option<String>,
     /// The font of the header label.
     #[serde(rename = "labelFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font: Option<String>,
     /// The font size of the header label, in pixels.
     #[serde(rename = "labelFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_size: Option<f64>,
     /// The maximum length of the header label in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
     #[serde(rename = "labelLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_limit: Option<f64>,
     /// The orthogonal distance in pixels by which to displace the title from its position along
     /// the edge of the chart.
     ///
     /// __Default value:__ `10`
     #[serde(rename = "labelPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_padding: Option<f64>,
     /// The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`. For
     /// example, with an orientation of top these anchor positions map to a left-, center-, or
@@ -1589,42 +1716,51 @@ pub struct HeaderConfig {
     /// [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite
     /// views, `anchor` is always `"start"`.
     #[serde(rename = "titleAnchor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_anchor: Option<String>,
     /// The rotation angle of the header title.
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "titleAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_angle: Option<f64>,
     /// Vertical text baseline for the header title. One of `"top"`, `"bottom"`, `"middle"`.
     ///
     /// __Default value:__ `"middle"`
     #[serde(rename = "titleBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_baseline: Option<TextBaseline>,
     /// Color of the header title, can be in hex color code or regular color name.
     #[serde(rename = "titleColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_color: Option<String>,
     /// Font of the header title. (e.g., `"Helvetica Neue"`).
     #[serde(rename = "titleFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font: Option<String>,
     /// Font size of the header title.
     #[serde(rename = "titleFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_size: Option<f64>,
     /// Font weight of the header title.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "titleFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_weight: Option<FontWeight>,
     /// The maximum length of the header title in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
     #[serde(rename = "titleLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_limit: Option<f64>,
     /// The orthogonal distance in pixels by which to displace the title from its position along
     /// the edge of the chart.
     ///
     /// __Default value:__ `10`
     #[serde(rename = "titlePadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_padding: Option<f64>,
 }
 
@@ -1636,58 +1772,71 @@ pub struct HeaderConfig {
 pub struct LegendConfig {
     /// The height in pixels to clip symbol legend entries and limit their size.
     #[serde(rename = "clipHeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clip_height: Option<f64>,
     /// The horizontal padding in pixels between symbol legend entries.
     ///
     /// __Default value:__ `10`.
     #[serde(rename = "columnPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column_padding: Option<f64>,
     /// The number of columns in which to arrange symbol legend entries. A value of `0` or lower
     /// indicates a single row with one column per entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<f64>,
     /// Corner radius for the full legend.
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// Background fill color for the full legend.
     #[serde(rename = "fillColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_color: Option<String>,
     /// The default direction (`"horizontal"` or `"vertical"`) for gradient legends.
     ///
     /// __Default value:__ `"vertical"`.
     #[serde(rename = "gradientDirection")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_direction: Option<Orient>,
     /// The maximum allowed length in pixels of color ramp gradient labels.
     #[serde(rename = "gradientLabelLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_label_limit: Option<f64>,
     /// Vertical offset in pixels for color ramp gradient labels.
     ///
     /// __Default value:__ `2`.
     #[serde(rename = "gradientLabelOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_label_offset: Option<f64>,
     /// The length in pixels of the primary axis of a color gradient. This value corresponds to
     /// the height of a vertical gradient or the width of a horizontal gradient.
     ///
     /// __Default value:__ `200`.
     #[serde(rename = "gradientLength")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_length: Option<f64>,
     /// Opacity of the color gradient.
     #[serde(rename = "gradientOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_opacity: Option<f64>,
     /// The color of the gradient stroke, can be in hex color code or regular color name.
     ///
     /// __Default value:__ `"lightGray"`.
     #[serde(rename = "gradientStrokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_stroke_color: Option<String>,
     /// The width of the gradient stroke, in pixels.
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "gradientStrokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_stroke_width: Option<f64>,
     /// The thickness in pixels of the color gradient. This value corresponds to the width of a
     /// vertical gradient or the height of a horizontal gradient.
     ///
     /// __Default value:__ `16`.
     #[serde(rename = "gradientThickness")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_thickness: Option<f64>,
     /// The alignment to apply to symbol legends rows and columns. The supported string values
     /// are `"all"`, `"each"` (the default), and `none`. For more information, see the [grid
@@ -1695,40 +1844,50 @@ pub struct LegendConfig {
     ///
     /// __Default value:__ `"each"`.
     #[serde(rename = "gridAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid_align: Option<VgLayoutAlign>,
     /// The alignment of the legend label, can be left, center, or right.
     #[serde(rename = "labelAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_align: Option<Align>,
     /// The position of the baseline of legend label, can be `"top"`, `"middle"`, `"bottom"`, or
     /// `"alphabetic"`.
     ///
     /// __Default value:__ `"middle"`.
     #[serde(rename = "labelBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_baseline: Option<TextBaseline>,
     /// The color of the legend label, can be in hex color code or regular color name.
     #[serde(rename = "labelColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_color: Option<String>,
     /// The font of the legend label.
     #[serde(rename = "labelFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font: Option<String>,
     /// The font size of legend label.
     ///
     /// __Default value:__ `10`.
     #[serde(rename = "labelFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_size: Option<f64>,
     /// The font weight of legend label.
     #[serde(rename = "labelFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_weight: Option<FontWeight>,
     /// Maximum allowed pixel width of axis tick labels.
     ///
     /// __Default value:__ `160`.
     #[serde(rename = "labelLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_limit: Option<f64>,
     /// The offset of the legend label.
     #[serde(rename = "labelOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_offset: Option<f64>,
     /// Opacity of labels.
     #[serde(rename = "labelOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_opacity: Option<f64>,
     /// The strategy to use for resolving overlap of labels in gradient legends. If `false`, no
     /// overlap reduction is attempted. If set to `true` (default) or `"parity"`, a strategy of
@@ -1739,83 +1898,102 @@ pub struct LegendConfig {
     /// __Default value:__ `"greedy"` for `log scales otherwise `true`.
     /// *
     #[serde(rename = "labelOverlap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_overlap: Option<LabelOverlap>,
     /// Padding in pixels between the legend and legend labels.
     #[serde(rename = "labelPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_padding: Option<f64>,
     /// The offset in pixels by which to displace the legend from the data rectangle and axes.
     ///
     /// __Default value:__ `18`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
     /// The orientation of the legend, which determines how the legend is positioned within the
     /// scene. One of "left", "right", "top-left", "top-right", "bottom-left", "bottom-right",
     /// "none".
     ///
     /// __Default value:__ `"right"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<LegendOrient>,
     /// The padding between the border and content of the legend group.
     ///
     /// __Default value:__ `0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding: Option<f64>,
     /// The vertical padding in pixels between symbol legend entries.
     ///
     /// __Default value:__ `2`.
     #[serde(rename = "rowPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row_padding: Option<f64>,
     /// Whether month names and weekday names should be abbreviated.
     ///
     /// __Default value:__  `false`
     #[serde(rename = "shortTimeLabels")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub short_time_labels: Option<bool>,
     /// Border stroke color for the full legend.
     #[serde(rename = "strokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_color: Option<String>,
     /// Border stroke dash pattern for the full legend.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// Border stroke width for the full legend.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// Default fill color for legend symbols. Only applied if there is no `"fill"` scale color
     /// encoding for the legend.
     ///
     /// __Default value:__ `"transparent"`.
     #[serde(rename = "symbolBaseFillColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_base_fill_color: Option<String>,
     /// Default stroke color for legend symbols. Only applied if there is no `"fill"` scale color
     /// encoding for the legend.
     ///
     /// __Default value:__ `"gray"`.
     #[serde(rename = "symbolBaseStrokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_base_stroke_color: Option<String>,
     /// The default direction (`"horizontal"` or `"vertical"`) for symbol legends.
     ///
     /// __Default value:__ `"vertical"`.
     #[serde(rename = "symbolDirection")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_direction: Option<Orient>,
     /// The color of the legend symbol,
     #[serde(rename = "symbolFillColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_fill_color: Option<String>,
     /// Horizontal pixel offset for legend symbols.
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "symbolOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_offset: Option<f64>,
     /// Opacity of the legend symbols.
     #[serde(rename = "symbolOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_opacity: Option<f64>,
     /// The size of the legend symbol, in pixels.
     ///
     /// __Default value:__ `100`.
     #[serde(rename = "symbolSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_size: Option<f64>,
     /// Stroke color for legend symbols.
     #[serde(rename = "symbolStrokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_stroke_color: Option<String>,
     /// The width of the symbol's stroke.
     ///
     /// __Default value:__ `1.5`.
     #[serde(rename = "symbolStrokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_stroke_width: Option<f64>,
     /// Default shape type (such as "circle") for legend symbols.
     /// Can be one of ``"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
@@ -1826,43 +2004,53 @@ pub struct LegendConfig {
     /// * __Default value:__ `"circle"`.
     /// *
     #[serde(rename = "symbolType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_type: Option<String>,
     /// Horizontal text alignment for legend titles.
     ///
     /// __Default value:__ `"left"`.
     #[serde(rename = "titleAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_align: Option<Align>,
     /// Vertical text baseline for legend titles.
     ///
     /// __Default value:__ `"top"`.
     #[serde(rename = "titleBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_baseline: Option<TextBaseline>,
     /// The color of the legend title, can be in hex color code or regular color name.
     #[serde(rename = "titleColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_color: Option<String>,
     /// The font of the legend title.
     #[serde(rename = "titleFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font: Option<String>,
     /// The font size of the legend title.
     #[serde(rename = "titleFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_size: Option<f64>,
     /// The font weight of the legend title.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "titleFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_weight: Option<FontWeight>,
     /// Maximum allowed pixel width of axis titles.
     ///
     /// __Default value:__ `180`.
     #[serde(rename = "titleLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_limit: Option<f64>,
     /// Opacity of the legend title.
     #[serde(rename = "titleOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_opacity: Option<f64>,
     /// The padding, in pixels, between title and legend.
     ///
     /// __Default value:__ `5`.
     #[serde(rename = "titlePadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_padding: Option<f64>,
 }
 
@@ -1872,12 +2060,15 @@ pub struct LegendConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LineConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The rotation angle of the text, in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
     ///
     /// __Default value:__ `"middle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Default color.  Note that `fill` and `stroke` have higher precedence than `color` and
     /// will override `color`.
@@ -1886,33 +2077,41 @@ pub struct LineConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// The radius in pixels of rounded rectangle corners.
     ///
     /// __Default value:__ `0`
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The mouse cursor used over the mark. Any valid [CSS cursor
     /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
     /// The direction of the text. One of `"ltr"` (left-to-right) or `"rtl"` (right-to-left).
     /// This property determines on which side is truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"ltr"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dir: Option<Dir>,
     /// The horizontal offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dx: Option<f64>,
     /// The vertical offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dy: Option<f64>,
     /// The ellipsis string for text truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"…"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ellipsis: Option<String>,
     /// Default Fill Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// Whether the mark's color should be used as fill color instead of stroke color.
     ///
@@ -1922,26 +2121,33 @@ pub struct LineConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filled: Option<bool>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The typeface to set the text in (e.g., `"Helvetica Neue"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// The font size, in pixels.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// The font style (e.g., `"italic"`).
     #[serde(rename = "fontStyle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<FontStyle>,
     /// The font weight.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// The line interpolation method to use for line and area marks. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -1961,16 +2167,19 @@ pub struct LineConfig {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The maximum length of the text mark in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The overall opacity (value between [0,1]).
     ///
     /// __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or
     /// `square` marks or layered `bar` charts and `1` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f64>,
     /// The orientation of a non-stacked bar, tick, area, and line charts.
     /// The value is either horizontal (default) or vertical.
@@ -1982,6 +2191,7 @@ pub struct LineConfig {
     /// if `config.sortLineBy` is not specified.
     /// For stacked charts, this is always determined by the orientation of the stack;
     /// therefore explicitly specified value will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<Orient>,
     /// A flag for overlaying points on top of line or area marks, or an object defining the
     /// properties of the overlayed points.
@@ -1996,14 +2206,17 @@ pub struct LineConfig {
     /// marks.
     ///
     /// __Default value:__ `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub point: Option<PointUnion>,
     /// Polar coordinate radial offset, in pixels, of the text label from the origin determined
     /// by the `x` and `y` properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
     /// The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`,
     /// `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
     ///
     /// __Default value:__ `"circle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
     /// Default size for marks.
     /// - For `point`/`circle`/`square`, this represents the pixel area of the marks. For
@@ -2015,46 +2228,58 @@ pub struct LineConfig {
     /// __Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks
     /// with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text
     /// marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
     /// Default Stroke Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
     ///
     /// __Default value:__ `"square"`
     #[serde(rename = "strokeCap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_cap: Option<StrokeCap>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of `"miter"`, `"round"` or `"bevel"`.
     ///
     /// __Default value:__ `"miter"`
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The miter limit at which to bevel a line join.
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// Depending on the interpolation type, sets the tension parameter (for line and area marks).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
     /// Placeholder text if the `text` channel is not specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// Polar coordinate angle, in radians, of the text label from the origin determined by the
     /// `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark
     /// `startAngle` and `endAngle` properties: angles are measured in radians, with `0`
     /// indicating "north".
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub theta: Option<f64>,
     /// The tooltip text string to show upon mouse hover or an object defining which fields
     /// should the tooltip be derived from.
@@ -2063,14 +2288,19 @@ pub struct LineConfig {
     /// used.
     /// - If `tooltip` is `{"content": "data"}`, then all fields that appear in the highlighted
     /// data point will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<Tooltip>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PaddingClass {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bottom: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub left: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub right: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub top: Option<f64>,
 }
 
@@ -2092,22 +2322,30 @@ pub struct Projection {
     /// and latitude in degrees.
     ///
     /// __Default value:__ `[0, 0]`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub center: Option<Vec<f64>>,
     /// Sets the projection’s clipping circle radius to the specified angle in degrees. If
     /// `null`, switches to [antimeridian](http://bl.ocks.org/mbostock/3788999) cutting rather
     /// than small-circle clipping.
     #[serde(rename = "clipAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clip_angle: Option<f64>,
     /// Sets the projection’s viewport clip extent to the specified bounds in pixels. The extent
     /// bounds are specified as an array `[[x0, y0], [x1, y1]]`, where `x0` is the left-side of
     /// the viewport, `y0` is the top, `x1` is the right and `y1` is the bottom. If `null`, no
     /// viewport clipping is performed.
     #[serde(rename = "clipExtent")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clip_extent: Option<Vec<Vec<f64>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub coefficient: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub distance: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fraction: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lobes: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parallel: Option<f64>,
     /// Sets the threshold for the projection’s [adaptive
     /// resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. This
@@ -2115,16 +2353,22 @@ pub struct Projection {
     /// distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm).
     /// If precision is not specified, returns the projection’s current resampling precision
     /// which defaults to `√0.5 ≅ 0.70710…`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub precision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ratio: Option<f64>,
     /// Sets the projection’s three-axis rotation to the specified angles, which must be a two-
     /// or three-element array of numbers [`lambda`, `phi`, `gamma`] specifying the rotation
     /// angles in degrees about each spherical axis. (These correspond to yaw, pitch and roll.)
     ///
     /// __Default value:__ `[0, 0, 0]`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rotate: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spacing: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tilt: Option<f64>,
     /// The cartographic projection to use. This value is case-insensitive, for example
     /// `"albers"` and `"Albers"` indicate the same projection type. You can find all valid
@@ -2133,14 +2377,19 @@ pub struct Projection {
     ///
     /// __Default value:__ `mercator`
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projection_type: Option<VgProjectionType>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VgScheme {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scheme: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub step: Option<f64>,
 }
 
@@ -2154,103 +2403,123 @@ pub struct ScaleConfig {
     ///
     /// __Default value:__ `0.1`
     #[serde(rename = "bandPaddingInner")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub band_padding_inner: Option<f64>,
     /// Default outer padding for `x` and `y` band-ordinal scales.
     /// If not specified, by default, band scale's paddingOuter is paddingInner/2.
     #[serde(rename = "bandPaddingOuter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub band_padding_outer: Option<f64>,
     /// If true, values that exceed the data domain are clamped to either the minimum or maximum
     /// range value
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clamp: Option<bool>,
     /// Default padding for continuous scales.
     ///
     /// __Default:__ `5` for continuous x-scale of a vertical bar and continuous y-scale of a
     /// horizontal bar.; `0` otherwise.
     #[serde(rename = "continuousPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub continuous_padding: Option<f64>,
     /// The default max value for mapping quantitative fields to bar's size/bandSize.
     ///
     /// If undefined (default), we will use the scale's `rangeStep` - 1.
     #[serde(rename = "maxBandSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_band_size: Option<f64>,
     /// The default max value for mapping quantitative fields to text's size/fontSize.
     ///
     /// __Default value:__ `40`
     #[serde(rename = "maxFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_font_size: Option<f64>,
     /// Default max opacity for mapping a field to opacity.
     ///
     /// __Default value:__ `0.8`
     #[serde(rename = "maxOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_opacity: Option<f64>,
     /// Default max value for point size scale.
     #[serde(rename = "maxSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_size: Option<f64>,
     /// Default max strokeWidth for the scale of strokeWidth for rule and line marks and of size
     /// for trail marks.
     ///
     /// __Default value:__ `4`
     #[serde(rename = "maxStrokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_stroke_width: Option<f64>,
     /// The default min value for mapping quantitative fields to bar and tick's size/bandSize
     /// scale with zero=false.
     ///
     /// __Default value:__ `2`
     #[serde(rename = "minBandSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_band_size: Option<f64>,
     /// The default min value for mapping quantitative fields to tick's size/fontSize scale with
     /// zero=false
     ///
     /// __Default value:__ `8`
     #[serde(rename = "minFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_font_size: Option<f64>,
     /// Default minimum opacity for mapping a field to opacity.
     ///
     /// __Default value:__ `0.3`
     #[serde(rename = "minOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_opacity: Option<f64>,
     /// Default minimum value for point size scale with zero=false.
     ///
     /// __Default value:__ `9`
     #[serde(rename = "minSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_size: Option<f64>,
     /// Default minimum strokeWidth for the scale of strokeWidth for rule and line marks and of
     /// size for trail marks with zero=false.
     ///
     /// __Default value:__ `1`
     #[serde(rename = "minStrokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_stroke_width: Option<f64>,
     /// Default outer padding for `x` and `y` point-ordinal scales.
     ///
     /// __Default value:__ `0.5`
     #[serde(rename = "pointPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub point_padding: Option<f64>,
     /// Default range cardinality for
     /// [`quantile`](https://vega.github.io/vega-lite/docs/scale.html#quantile) scale.
     ///
     /// __Default value:__ `4`
     #[serde(rename = "quantileCount")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quantile_count: Option<f64>,
     /// Default range cardinality for
     /// [`quantize`](https://vega.github.io/vega-lite/docs/scale.html#quantize) scale.
     ///
     /// __Default value:__ `4`
     #[serde(rename = "quantizeCount")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quantize_count: Option<f64>,
     /// Default range step for band and point scales of (1) the `y` channel
     /// and (2) the `x` channel when the mark is not `text`.
     ///
     /// __Default value:__ `21`
     #[serde(rename = "rangeStep")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub range_step: Option<f64>,
     /// If true, rounds numeric output values to integers.
     /// This can be helpful for snapping to the pixel grid.
     /// (Only available for `x`, `y`, and `size` scales.)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub round: Option<bool>,
     /// Default range step for `x` band and point scales of text marks.
     ///
     /// __Default value:__ `90`
     #[serde(rename = "textXRangeStep")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_x_range_step: Option<f64>,
     /// Use the source data range before aggregation as scale domain instead of aggregated data
     /// for aggregate axis.
@@ -2265,6 +2534,7 @@ pub struct ScaleConfig {
     ///
     /// __Default value:__ `false`
     #[serde(rename = "useUnaggregatedDomain")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub use_unaggregated_domain: Option<bool>,
 }
 
@@ -2278,6 +2548,7 @@ pub struct SelectionConfig {
     ///
     /// For instance, setting `interval` to `{"translate": false}` disables the ability to move
     /// interval selections by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<IntervalSelectionConfig>,
     /// The default definition for a
     /// [`multi`](https://vega.github.io/vega-lite/docs/selection.html#type) selection. All
@@ -2286,6 +2557,7 @@ pub struct SelectionConfig {
     ///
     /// For instance, setting `multi` to `{"toggle": "event.altKey"}` adds additional values to
     /// multi selections when clicking with the alt-key pressed by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub multi: Option<MultiSelectionConfig>,
     /// The default definition for a
     /// [`single`](https://vega.github.io/vega-lite/docs/selection.html#type) selection. All
@@ -2294,6 +2566,7 @@ pub struct SelectionConfig {
     ///
     /// For instance, setting `single` to `{"on": "dblclick"}` populates single selections on
     /// double-click by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub single: Option<SingleSelectionConfig>,
 }
 
@@ -2309,28 +2582,35 @@ pub struct IntervalSelectionConfig {
     /// Establishes a two-way binding between the interval selection and the scales
     /// used within the same view. This allows a user to interactively pan and
     /// zoom the view.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bind: Option<BindEnum>,
     /// By default, all data values are considered to lie within an empty selection.
     /// When set to `none`, empty selections contain no data values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub empty: Option<VgLayoutAlign>,
     /// An array of encoding channels. The corresponding data field values
     /// must match for a data tuple to fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encodings: Option<Vec<SingleDefChannel>>,
     /// An array of field names whose values must match for a data tuple to
     /// fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<String>>,
     /// An interval selection also adds a rectangle mark to depict the
     /// extents of the interval. The `mark` property can be used to customize the
     /// appearance of the mark.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<BrushConfig>,
     /// A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
     /// selector) that triggers the selection.
     /// For interval selections, the event stream must specify a [start and
     /// end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<serde_json::Value>,
     /// With layered and multi-view displays, a strategy that determines how
     /// selections' data queries are resolved when applied in a filter transform,
     /// conditional encoding rule, or scale domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<SelectionResolution>,
     /// When truthy, allows a user to interactively move an interval selection
     /// back-and-forth. Can be `true`, `false` (to disable panning), or a
@@ -2340,6 +2620,7 @@ pub struct IntervalSelectionConfig {
     /// __Default value:__ `true`, which corresponds to
     /// `[mousedown, window:mouseup] > window:mousemove!` which corresponds to
     /// clicks and dragging within an interval selection to reposition it.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub translate: Option<Translate>,
     /// When truthy, allows a user to interactively resize an interval selection.
     /// Can be `true`, `false` (to disable zooming), or a [Vega event stream
@@ -2348,6 +2629,7 @@ pub struct IntervalSelectionConfig {
     ///
     ///
     /// __Default value:__ `true`, which corresponds to `wheel!`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zoom: Option<Translate>,
 }
 
@@ -2359,28 +2641,35 @@ pub struct BrushConfig {
     /// The fill color of the interval mark.
     ///
     /// __Default value:__ `#333333`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// The fill opacity of the interval mark (a value between 0 and 1).
     ///
     /// __Default value:__ `0.125`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The stroke color of the interval mark.
     ///
     /// __Default value:__ `#ffffff`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// An array of alternating stroke and space lengths,
     /// for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) with which to begin drawing the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke opacity of the interval mark (a value between 0 and 1).
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width of the interval mark.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
 }
 
@@ -2395,27 +2684,33 @@ pub struct BrushConfig {
 pub struct MultiSelectionConfig {
     /// By default, all data values are considered to lie within an empty selection.
     /// When set to `none`, empty selections contain no data values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub empty: Option<VgLayoutAlign>,
     /// An array of encoding channels. The corresponding data field values
     /// must match for a data tuple to fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encodings: Option<Vec<SingleDefChannel>>,
     /// An array of field names whose values must match for a data tuple to
     /// fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<String>>,
     /// When true, an invisible voronoi diagram is computed to accelerate discrete
     /// selection. The data value _nearest_ the mouse cursor is added to the selection.
     ///
     /// See the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html)
     /// documentation for more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nearest: Option<bool>,
     /// A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
     /// selector) that triggers the selection.
     /// For interval selections, the event stream must specify a [start and
     /// end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<serde_json::Value>,
     /// With layered and multi-view displays, a strategy that determines how
     /// selections' data queries are resolved when applied in a filter transform,
     /// conditional encoding rule, or scale domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<SelectionResolution>,
     /// Controls whether data values should be toggled or only ever inserted into
     /// multi selections. Can be `true`, `false` (for insertion only), or a
@@ -2426,6 +2721,7 @@ pub struct MultiSelectionConfig {
     ///
     /// See the [toggle transform](https://vega.github.io/vega-lite/docs/toggle.html)
     /// documentation for more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub toggle: Option<Translate>,
 }
 
@@ -2445,99 +2741,127 @@ pub struct SingleSelectionConfig {
     ///
     /// See the [bind transform](https://vega.github.io/vega-lite/docs/bind.html) documentation
     /// for more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bind: Option<HashMap<String, BindValue>>,
     /// By default, all data values are considered to lie within an empty selection.
     /// When set to `none`, empty selections contain no data values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub empty: Option<VgLayoutAlign>,
     /// An array of encoding channels. The corresponding data field values
     /// must match for a data tuple to fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encodings: Option<Vec<SingleDefChannel>>,
     /// An array of field names whose values must match for a data tuple to
     /// fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<String>>,
     /// When true, an invisible voronoi diagram is computed to accelerate discrete
     /// selection. The data value _nearest_ the mouse cursor is added to the selection.
     ///
     /// See the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html)
     /// documentation for more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nearest: Option<bool>,
     /// A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
     /// selector) that triggers the selection.
     /// For interval selections, the event stream must specify a [start and
     /// end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<serde_json::Value>,
     /// With layered and multi-view displays, a strategy that determines how
     /// selections' data queries are resolved when applied in a filter transform,
     /// conditional encoding rule, or scale domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<SelectionResolution>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VgBinding {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub element: Option<String>,
     pub input: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub step: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VgMarkConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The rotation angle of the text, in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
     ///
     /// __Default value:__ `"middle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// The radius in pixels of rounded rectangle corners.
     ///
     /// __Default value:__ `0`
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The mouse cursor used over the mark. Any valid [CSS cursor
     /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
     /// The direction of the text. One of `"ltr"` (left-to-right) or `"rtl"` (right-to-left).
     /// This property determines on which side is truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"ltr"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dir: Option<Dir>,
     /// The horizontal offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dx: Option<f64>,
     /// The vertical offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dy: Option<f64>,
     /// The ellipsis string for text truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"…"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ellipsis: Option<String>,
     /// Default Fill Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The typeface to set the text in (e.g., `"Helvetica Neue"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// The font size, in pixels.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// The font style (e.g., `"italic"`).
     #[serde(rename = "fontStyle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<FontStyle>,
     /// The font weight.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// The line interpolation method to use for line and area marks. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -2557,16 +2881,19 @@ pub struct VgMarkConfig {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The maximum length of the text mark in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The overall opacity (value between [0,1]).
     ///
     /// __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or
     /// `square` marks or layered `bar` charts and `1` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f64>,
     /// The orientation of a non-stacked bar, tick, area, and line charts.
     /// The value is either horizontal (default) or vertical.
@@ -2578,62 +2905,78 @@ pub struct VgMarkConfig {
     /// if `config.sortLineBy` is not specified.
     /// For stacked charts, this is always determined by the orientation of the stack;
     /// therefore explicitly specified value will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<Orient>,
     /// Polar coordinate radial offset, in pixels, of the text label from the origin determined
     /// by the `x` and `y` properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
     /// The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`,
     /// `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
     ///
     /// __Default value:__ `"circle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
     /// The pixel area each the point/circle/square.
     /// For example: in the case of circles, the radius is determined in part by the square root
     /// of the size value.
     ///
     /// __Default value:__ `30`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
     /// Default Stroke Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
     ///
     /// __Default value:__ `"square"`
     #[serde(rename = "strokeCap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_cap: Option<StrokeCap>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of `"miter"`, `"round"` or `"bevel"`.
     ///
     /// __Default value:__ `"miter"`
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The miter limit at which to bevel a line join.
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// Depending on the interpolation type, sets the tension parameter (for line and area marks).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
     /// Placeholder text if the `text` channel is not specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// Polar coordinate angle, in radians, of the text label from the origin determined by the
     /// `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark
     /// `startAngle` and `endAngle` properties: angles are measured in radians, with `0`
     /// indicating "north".
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub theta: Option<f64>,
     /// The tooltip text to show upon mouse hover.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<serde_json::Value>,
 }
 
@@ -2641,12 +2984,15 @@ pub struct VgMarkConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TextConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The rotation angle of the text, in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
     ///
     /// __Default value:__ `"middle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Default color.  Note that `fill` and `stroke` have higher precedence than `color` and
     /// will override `color`.
@@ -2655,33 +3001,41 @@ pub struct TextConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// The radius in pixels of rounded rectangle corners.
     ///
     /// __Default value:__ `0`
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The mouse cursor used over the mark. Any valid [CSS cursor
     /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
     /// The direction of the text. One of `"ltr"` (left-to-right) or `"rtl"` (right-to-left).
     /// This property determines on which side is truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"ltr"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dir: Option<Dir>,
     /// The horizontal offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dx: Option<f64>,
     /// The vertical offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dy: Option<f64>,
     /// The ellipsis string for text truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"…"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ellipsis: Option<String>,
     /// Default Fill Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// Whether the mark's color should be used as fill color instead of stroke color.
     ///
@@ -2691,26 +3045,33 @@ pub struct TextConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filled: Option<bool>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The typeface to set the text in (e.g., `"Helvetica Neue"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// The font size, in pixels.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// The font style (e.g., `"italic"`).
     #[serde(rename = "fontStyle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<FontStyle>,
     /// The font weight.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// The line interpolation method to use for line and area marks. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -2730,16 +3091,19 @@ pub struct TextConfig {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The maximum length of the text mark in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The overall opacity (value between [0,1]).
     ///
     /// __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or
     /// `square` marks or layered `bar` charts and `1` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f64>,
     /// The orientation of a non-stacked bar, tick, area, and line charts.
     /// The value is either horizontal (default) or vertical.
@@ -2751,17 +3115,21 @@ pub struct TextConfig {
     /// if `config.sortLineBy` is not specified.
     /// For stacked charts, this is always determined by the orientation of the stack;
     /// therefore explicitly specified value will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<Orient>,
     /// Polar coordinate radial offset, in pixels, of the text label from the origin determined
     /// by the `x` and `y` properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
     /// The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`,
     /// `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
     ///
     /// __Default value:__ `"circle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
     /// Whether month names and weekday names should be abbreviated.
     #[serde(rename = "shortTimeLabels")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub short_time_labels: Option<bool>,
     /// Default size for marks.
     /// - For `point`/`circle`/`square`, this represents the pixel area of the marks. For
@@ -2773,46 +3141,58 @@ pub struct TextConfig {
     /// __Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks
     /// with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text
     /// marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
     /// Default Stroke Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
     ///
     /// __Default value:__ `"square"`
     #[serde(rename = "strokeCap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_cap: Option<StrokeCap>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of `"miter"`, `"round"` or `"bevel"`.
     ///
     /// __Default value:__ `"miter"`
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The miter limit at which to bevel a line join.
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// Depending on the interpolation type, sets the tension parameter (for line and area marks).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
     /// Placeholder text if the `text` channel is not specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// Polar coordinate angle, in radians, of the text label from the origin determined by the
     /// `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark
     /// `startAngle` and `endAngle` properties: angles are measured in radians, with `0`
     /// indicating "north".
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub theta: Option<f64>,
     /// The tooltip text string to show upon mouse hover or an object defining which fields
     /// should the tooltip be derived from.
@@ -2821,6 +3201,7 @@ pub struct TextConfig {
     /// used.
     /// - If `tooltip` is `{"content": "data"}`, then all fields that appear in the highlighted
     /// data point will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<Tooltip>,
 }
 
@@ -2828,17 +3209,21 @@ pub struct TextConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TickConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The rotation angle of the text, in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// The width of the ticks.
     ///
     /// __Default value:__  2/3 of rangeStep.
     #[serde(rename = "bandSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub band_size: Option<f64>,
     /// The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
     ///
     /// __Default value:__ `"middle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Default color.  Note that `fill` and `stroke` have higher precedence than `color` and
     /// will override `color`.
@@ -2847,33 +3232,41 @@ pub struct TickConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// The radius in pixels of rounded rectangle corners.
     ///
     /// __Default value:__ `0`
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The mouse cursor used over the mark. Any valid [CSS cursor
     /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
     /// The direction of the text. One of `"ltr"` (left-to-right) or `"rtl"` (right-to-left).
     /// This property determines on which side is truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"ltr"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dir: Option<Dir>,
     /// The horizontal offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dx: Option<f64>,
     /// The vertical offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dy: Option<f64>,
     /// The ellipsis string for text truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"…"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ellipsis: Option<String>,
     /// Default Fill Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// Whether the mark's color should be used as fill color instead of stroke color.
     ///
@@ -2883,26 +3276,33 @@ pub struct TickConfig {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filled: Option<bool>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The typeface to set the text in (e.g., `"Helvetica Neue"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// The font size, in pixels.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// The font style (e.g., `"italic"`).
     #[serde(rename = "fontStyle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<FontStyle>,
     /// The font weight.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// The line interpolation method to use for line and area marks. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -2922,16 +3322,19 @@ pub struct TickConfig {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The maximum length of the text mark in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The overall opacity (value between [0,1]).
     ///
     /// __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or
     /// `square` marks or layered `bar` charts and `1` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f64>,
     /// The orientation of a non-stacked bar, tick, area, and line charts.
     /// The value is either horizontal (default) or vertical.
@@ -2943,14 +3346,17 @@ pub struct TickConfig {
     /// if `config.sortLineBy` is not specified.
     /// For stacked charts, this is always determined by the orientation of the stack;
     /// therefore explicitly specified value will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<Orient>,
     /// Polar coordinate radial offset, in pixels, of the text label from the origin determined
     /// by the `x` and `y` properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
     /// The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`,
     /// `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
     ///
     /// __Default value:__ `"circle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
     /// Default size for marks.
     /// - For `point`/`circle`/`square`, this represents the pixel area of the marks. For
@@ -2962,50 +3368,63 @@ pub struct TickConfig {
     /// __Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks
     /// with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text
     /// marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
     /// Default Stroke Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
     ///
     /// __Default value:__ `"square"`
     #[serde(rename = "strokeCap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_cap: Option<StrokeCap>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of `"miter"`, `"round"` or `"bevel"`.
     ///
     /// __Default value:__ `"miter"`
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The miter limit at which to bevel a line join.
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// Depending on the interpolation type, sets the tension parameter (for line and area marks).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
     /// Placeholder text if the `text` channel is not specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// Polar coordinate angle, in radians, of the text label from the origin determined by the
     /// `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark
     /// `startAngle` and `endAngle` properties: angles are measured in radians, with `0`
     /// indicating "north".
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub theta: Option<f64>,
     /// Thickness of the tick mark.
     ///
     /// __Default value:__  `1`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub thickness: Option<f64>,
     /// The tooltip text string to show upon mouse hover or an object defining which fields
     /// should the tooltip be derived from.
@@ -3014,6 +3433,7 @@ pub struct TickConfig {
     /// used.
     /// - If `tooltip` is `{"content": "data"}`, then all fields that appear in the highlighted
     /// data point will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<Tooltip>,
 }
 
@@ -3023,39 +3443,51 @@ pub struct TickConfig {
 /// documentation](https://vega.github.io/vega-lite/docs/title.html#config).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct VgTitleConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`. For
     /// example, with an orientation of top these anchor positions map to a left-, center-, or
     /// right-aligned title.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub anchor: Option<TitleAnchor>,
     /// Angle in degrees of title text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// Vertical text baseline for title text. One of `"top"`, `"middle"`, `"bottom"`, or
     /// `"alphabetic"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Text color for title text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// Font name for title text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// Font size in pixels for title text.
     ///
     /// __Default value:__ `10`.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// Font weight for title text.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// The reference frame for the anchor position, one of `"bounds"` (to anchor relative to the
     /// full bounding box) or `"group"` (to anchor relative to the group width or height).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub frame: Option<TitleFrame>,
     /// The maximum allowed length in pixels of legend labels.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The orthogonal offset in pixels by which to displace the title from its position along
     /// the edge of the chart.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
     /// Default title orientation (`"top"`, `"bottom"`, `"left"`, or `"right"`)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<LegendOrient>,
 }
 
@@ -3064,60 +3496,72 @@ pub struct VgTitleConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ViewConfig {
     /// Whether the view should be clipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clip: Option<bool>,
     /// The fill color.
     ///
     /// __Default value:__ (none)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ (none)
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The default height of the single plot or each plot in a trellis plot when the
     /// visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.
     ///
     /// __Default value:__ `200`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<f64>,
     /// The stroke color.
     ///
     /// __Default value:__ (none)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     ///
     /// __Default value:__ (none)
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     ///
     /// __Default value:__ (none)
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of miter (default), round or bevel.
     ///
     /// __Default value:__ 'miter'
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The stroke line join method. One of miter (default), round or bevel.
     ///
     /// __Default value:__ 'miter'
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ (none)
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     ///
     /// __Default value:__ (none)
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// The default width of the single plot or each plot in a trellis plot when the
     /// visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep`
     /// = `null`.
     ///
     /// __Default value:__ `200`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<f64>,
 }
 
@@ -3127,16 +3571,20 @@ pub struct ViewConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Data {
     /// An object that specifies the format for parsing the data.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<DataFormat>,
     /// Provide a placeholder name and bind data at runtime.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// An URL from which to load the data set. Use the `format.type` property
     /// to ensure the loaded data is correctly parsed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     /// The full data set, included inline. This can be an array of objects or primitive values,
     /// an object, or a string.
     /// Arrays of primitive values are ingested as objects with a `data` property. Strings are
     /// parsed according to the specified format type.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<DataInlineDataset>,
 }
 
@@ -3157,14 +3605,17 @@ pub struct DataFormat {
     /// [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date
     /// format parsing is supported similarly (e.g., `{foo: 'utc:"%m%d%Y"'}`). See more about
     /// [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parse: Option<HashMap<String, Option<String>>>,
     /// Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
     /// The default format type is determined by the extension of the file URL.
     /// If no extension is detected, `"json"` will be used by default.
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_format_type: Option<DataFormatType>,
     /// The delimiter between records. The delimiter must be a single character (i.e., a single
     /// 16-bit code unit); so, ASCII delimiters are fine, but emoji delimiters are not.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<String>,
     /// The JSON property containing the desired data.
     /// This parameter can be used when the loaded JSON file may have surrounding structure or
@@ -3172,11 +3623,13 @@ pub struct DataFormat {
     /// For example `"property": "values.features"` is equivalent to retrieving
     /// `json.values.features`
     /// from the loaded JSON object.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub property: Option<String>,
     /// The name of the TopoJSON object set to convert to a GeoJSON feature collection.
     /// For example, in a map of the world, there may be an object set named `"countries"`.
     /// Using the feature property, we can extract this set and generate a GeoJSON feature object
     /// for each country.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub feature: Option<String>,
     /// The name of the TopoJSON object set to convert to mesh.
     /// Similar to the `feature` option, `mesh` extracts a named TopoJSON object set.
@@ -3185,6 +3638,7 @@ pub struct DataFormat {
     /// Extracting a mesh is useful for more efficiently drawing borders or other geographic
     /// elements that you do not need to associate with specific regions such as individual
     /// countries, states or counties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mesh: Option<String>,
 }
 
@@ -3209,11 +3663,14 @@ pub struct Encoding {
     /// channel will be ignored.
     /// 2) See the scale documentation for more information about customizing [color
     /// scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<MarkPropDefWithCondition>,
     /// Horizontal facets for trellis plots.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<FacetFieldDef>,
     /// Additional levels of detail for grouping data in aggregate views and
     /// in line, trail, and area marks without mapping data to a specific visual channel.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<Detail>,
     /// Fill color of the marks.
     /// __Default value:__ If undefined, the default color depends on [mark
@@ -3221,27 +3678,35 @@ pub struct Encoding {
     ///
     /// _Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both
     /// fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<MarkPropDefWithCondition>,
     /// A URL to load upon mouse click.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<DefWithCondition>,
     /// A data field to use as a unique key for data binding. When a visualization’s data is
     /// updated, the key value will be used to match data elements to existing mark instances.
     /// Use a key channel to enable object constancy for transitions over dynamic data.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<FieldDef>,
     /// Latitude position of geographically projected marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub latitude: Option<FieldDef>,
     /// Latitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`, and
     /// `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub latitude2: Option<FieldDef>,
     /// Longitude position of geographically projected marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub longitude: Option<FieldDef>,
     /// Longitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`,
     /// and  `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub longitude2: Option<FieldDef>,
     /// Opacity of the marks – either can be a value or a range.
     ///
     /// __Default value:__ If undefined, the default opacity depends on [mark
     /// config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<MarkPropDefWithCondition>,
     /// Order of the marks.
     /// - For stacked marks, this `order` channel encodes [stack
@@ -3255,8 +3720,10 @@ pub struct Encoding {
     ///
     /// __Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating
     /// additional aggregation grouping.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<Order>,
     /// Vertical facets for trellis plots.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<FacetFieldDef>,
     /// For `point` marks the supported values are
     /// `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
@@ -3266,6 +3733,7 @@ pub struct Encoding {
     /// __Default value:__ If undefined, the default shape depends on [mark
     /// config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape`
     /// property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<MarkPropDefWithCondition>,
     /// Size of the mark.
     /// - For `"point"`, `"square"` and `"circle"`, – the symbol size, or pixel area of the mark.
@@ -3273,6 +3741,7 @@ pub struct Encoding {
     /// - For `"text"` – the text's font size.
     /// - Size is unsupported for `"line"`, `"area"`, and `"rect"`. (Use `"trail"` instead of
     /// line with varying size)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<MarkPropDefWithCondition>,
     /// Stroke color of the marks.
     /// __Default value:__ If undefined, the default color depends on [mark
@@ -3280,18 +3749,25 @@ pub struct Encoding {
     ///
     /// _Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both
     /// stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<MarkPropDefWithCondition>,
     /// Text of the `text` mark.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextClass>,
     /// The tooltip text to show upon mouse hover.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<EncodingTooltip>,
     /// X coordinates of the marks, or width of horizontal `"bar"` and `"area"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x: Option<XClass>,
     /// X2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x2: Option<X2Class>,
     /// Y coordinates of the marks, or height of vertical `"bar"` and `"area"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y: Option<XClass>,
     /// Y2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y2: Option<X2Class>,
 }
 
@@ -3364,6 +3840,7 @@ pub struct MarkPropDefWithCondition {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -3381,6 +3858,7 @@ pub struct MarkPropDefWithCondition {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// One or more value definition(s) with a selection predicate.
     ///
@@ -3389,6 +3867,7 @@ pub struct MarkPropDefWithCondition {
     /// since Vega-Lite only allows at most one encoded field per encoding channel.
     ///
     /// A field definition or one or more value definition(s) with a selection predicate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<ColorCondition>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -3402,12 +3881,14 @@ pub struct MarkPropDefWithCondition {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// An object defining properties of the legend.
     /// If `null`, the legend for the encoding channel will be removed.
     ///
     /// __Default value:__ If undefined, default [legend
     /// properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub legend: Option<Legend>,
     /// An object defining properties of the channel's scale, which is the function that
     /// transforms values in the data domain (numbers, dates, strings, etc) to visual values
@@ -3418,6 +3899,7 @@ pub struct MarkPropDefWithCondition {
     ///
     /// __Default value:__ If undefined, default [scale
     /// properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<Scale>,
     /// Sort order for the encoded field.
     ///
@@ -3441,6 +3923,7 @@ pub struct MarkPropDefWithCondition {
     /// __Default value:__ `"ascending"`
     ///
     /// __Note:__ `null` is not supported for `row` and `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Sort>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -3448,6 +3931,7 @@ pub struct MarkPropDefWithCondition {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -3467,14 +3951,17 @@ pub struct MarkPropDefWithCondition {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark_prop_def_with_condition_type: Option<Type>,
     /// A constant value in visual domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
@@ -3485,10 +3972,12 @@ pub struct BinParams {
     /// necessary to ensure that a boundary aligns with the anchor value.
     ///
     /// __Default Value:__ the minimum bin extent value
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub anchor: Option<f64>,
     /// The number base to use for automatic bin determination (default is base 10).
     ///
     /// __Default value:__ `10`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base: Option<f64>,
     /// Scale factors indicating allowable subdivisions. The default value is [5, 2], which
     /// indicates that for base 10 numbers (the default base), the method may consider dividing
@@ -3497,75 +3986,102 @@ pub struct BinParams {
     /// given constraints.
     ///
     /// __Default value:__ `[5, 2]`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub divide: Option<Vec<f64>>,
     /// A two-element (`[min, max]`) array indicating the range of desired bin values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<Vec<f64>>,
     /// Maximum number of bins.
     ///
     /// __Default value:__ `6` for `row`, `column` and `shape` channels; `10` for other channels
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub maxbins: Option<f64>,
     /// A minimum allowable step size (particularly useful for integer values).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub minstep: Option<f64>,
     /// If true (the default), attempts to make the bin boundaries use human-friendly boundaries,
     /// such as multiples of ten.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nice: Option<bool>,
     /// An exact step size to use between bins.
     ///
     /// __Note:__ If provided, options such as maxbins will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub step: Option<f64>,
     /// An array of allowable step sizes to choose from.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub steps: Option<Vec<f64>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConditionalValueDef {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
     /// A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of
     /// [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<SelectionOperand>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Selection {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub not: Option<Box<SelectionOperand>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub and: Option<Vec<SelectionOperand>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub or: Option<Vec<SelectionOperand>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Predicate {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub not: Option<Box<LogicalOperandPredicate>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub and: Option<Vec<LogicalOperandPredicate>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub or: Option<Vec<LogicalOperandPredicate>>,
     /// The value that the field should be equal to.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub equal: Option<EqualUnion>,
     /// Field to be filtered.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     /// Time unit for the field to be filtered.
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// An array of inclusive minimum and maximum values
     /// for a field value of a data item to be included in the filtered data.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub range: Option<Vec<Option<PurpleRange>>>,
     /// A set of values that the `field`'s value should be a member of,
     /// for a data item included in the filtered data.
     #[serde(rename = "oneOf")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub one_of: Option<Vec<SortElement>>,
     /// The value that the field should be less than.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lt: Option<Lt>,
     /// The value that the field should be greater than.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gt: Option<Lt>,
     /// The value that the field should be less than or equals to.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lte: Option<Lt>,
     /// The value that the field should be greater than or equals to.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gte: Option<Lt>,
     /// If set to true the field's value has to be valid, meaning both not `null` and not
     /// [`NaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NaN).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub valid: Option<bool>,
     /// Filter using a selection name.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<Box<SelectionOperand>>,
 }
 
@@ -3576,47 +4092,61 @@ pub struct Predicate {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DateTime {
     /// Integer value representing the date from 1-31.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<f64>,
     /// Value representing the day of a week.  This can be one of: (1) integer value -- `1`
     /// represents Monday; (2) case-insensitive day name (e.g., `"Monday"`);  (3)
     /// case-insensitive, 3-character short day name (e.g., `"Mon"`).   <br/> **Warning:** A
     /// DateTime definition object with `day`** should not be combined with `year`, `quarter`,
     /// `month`, or `date`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub day: Option<Day>,
     /// Integer value representing the hour of a day from 0-23.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hours: Option<f64>,
     /// Integer value representing the millisecond segment of time.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub milliseconds: Option<f64>,
     /// Integer value representing the minute segment of time from 0-59.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub minutes: Option<f64>,
     /// One of: (1) integer value representing the month from `1`-`12`. `1` represents January;
     /// (2) case-insensitive month name (e.g., `"January"`);  (3) case-insensitive, 3-character
     /// short month name (e.g., `"Jan"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub month: Option<Month>,
     /// Integer value representing the quarter of the year (from 1-4).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quarter: Option<f64>,
     /// Integer value representing the second segment (0-59) of a time value
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub seconds: Option<f64>,
     /// A boolean flag indicating if date time is in utc time. If false, the date time is in
     /// local time
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub utc: Option<bool>,
     /// Integer value representing the year.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub year: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConditionalPredicateMarkPropFieldDefClass {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
     /// A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of
     /// [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<SelectionOperand>,
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -3634,6 +4164,7 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -3647,12 +4178,14 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// An object defining properties of the legend.
     /// If `null`, the legend for the encoding channel will be removed.
     ///
     /// __Default value:__ If undefined, default [legend
     /// properties](https://vega.github.io/vega-lite/docs/legend.html) are applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub legend: Option<Legend>,
     /// An object defining properties of the channel's scale, which is the function that
     /// transforms values in the data domain (numbers, dates, strings, etc) to visual values
@@ -3663,6 +4196,7 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
     ///
     /// __Default value:__ If undefined, default [scale
     /// properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<Scale>,
     /// Sort order for the encoded field.
     ///
@@ -3686,6 +4220,7 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
     /// __Default value:__ `"ascending"`
     ///
     /// __Note:__ `null` is not supported for `row` and `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Sort>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -3693,6 +4228,7 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -3712,12 +4248,14 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conditional_def_type: Option<Type>,
 }
 
@@ -3732,22 +4270,28 @@ pub struct RepeatRef {
 pub struct Legend {
     /// The height in pixels to clip symbol legend entries and limit their size.
     #[serde(rename = "clipHeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clip_height: Option<f64>,
     /// The horizontal padding in pixels between symbol legend entries.
     ///
     /// __Default value:__ `10`.
     #[serde(rename = "columnPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column_padding: Option<f64>,
     /// The number of columns in which to arrange symbol legend entries. A value of `0` or lower
     /// indicates a single row with one column per entry.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub columns: Option<f64>,
     /// Corner radius for the full legend.
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The direction of the legend, one of `"vertical"` (default) or `"horizontal"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<Orient>,
     /// Background fill color for the full legend.
     #[serde(rename = "fillColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_color: Option<String>,
     /// The formatting pattern for labels. This is D3's [number format
     /// pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and D3's
@@ -3762,31 +4306,37 @@ pub struct Legend {
     /// quantitative fields and from
     /// [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for
     /// temporal fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// The length in pixels of the primary axis of a color gradient. This value corresponds to
     /// the height of a vertical gradient or the width of a horizontal gradient.
     ///
     /// __Default value:__ `200`.
     #[serde(rename = "gradientLength")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_length: Option<f64>,
     /// Opacity of the color gradient.
     #[serde(rename = "gradientOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_opacity: Option<f64>,
     /// The color of the gradient stroke, can be in hex color code or regular color name.
     ///
     /// __Default value:__ `"lightGray"`.
     #[serde(rename = "gradientStrokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_stroke_color: Option<String>,
     /// The width of the gradient stroke, in pixels.
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "gradientStrokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_stroke_width: Option<f64>,
     /// The thickness in pixels of the color gradient. This value corresponds to the width of a
     /// vertical gradient or the height of a horizontal gradient.
     ///
     /// __Default value:__ `16`.
     #[serde(rename = "gradientThickness")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gradient_thickness: Option<f64>,
     /// The alignment to apply to symbol legends rows and columns. The supported string values
     /// are `"all"`, `"each"` (the default), and `none`. For more information, see the [grid
@@ -3794,40 +4344,50 @@ pub struct Legend {
     ///
     /// __Default value:__ `"each"`.
     #[serde(rename = "gridAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid_align: Option<VgLayoutAlign>,
     /// The alignment of the legend label, can be left, center, or right.
     #[serde(rename = "labelAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_align: Option<Align>,
     /// The position of the baseline of legend label, can be `"top"`, `"middle"`, `"bottom"`, or
     /// `"alphabetic"`.
     ///
     /// __Default value:__ `"middle"`.
     #[serde(rename = "labelBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_baseline: Option<TextBaseline>,
     /// The color of the legend label, can be in hex color code or regular color name.
     #[serde(rename = "labelColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_color: Option<String>,
     /// The font of the legend label.
     #[serde(rename = "labelFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font: Option<String>,
     /// The font size of legend label.
     ///
     /// __Default value:__ `10`.
     #[serde(rename = "labelFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_size: Option<f64>,
     /// The font weight of legend label.
     #[serde(rename = "labelFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_weight: Option<FontWeight>,
     /// Maximum allowed pixel width of axis tick labels.
     ///
     /// __Default value:__ `160`.
     #[serde(rename = "labelLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_limit: Option<f64>,
     /// The offset of the legend label.
     #[serde(rename = "labelOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_offset: Option<f64>,
     /// Opacity of labels.
     #[serde(rename = "labelOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_opacity: Option<f64>,
     /// The strategy to use for resolving overlap of labels in gradient legends. If `false`, no
     /// overlap reduction is attempted. If set to `true` (default) or `"parity"`, a strategy of
@@ -3837,58 +4397,72 @@ pub struct Legend {
     ///
     /// __Default value:__ `true`.
     #[serde(rename = "labelOverlap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_overlap: Option<LabelOverlap>,
     /// Padding in pixels between the legend and legend labels.
     #[serde(rename = "labelPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_padding: Option<f64>,
     /// The offset in pixels by which to displace the legend from the data rectangle and axes.
     ///
     /// __Default value:__ `18`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
     /// The orientation of the legend, which determines how the legend is positioned within the
     /// scene. One of "left", "right", "top-left", "top-right", "bottom-left", "bottom-right",
     /// "none".
     ///
     /// __Default value:__ `"right"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<LegendOrient>,
     /// The padding between the border and content of the legend group.
     ///
     /// __Default value:__ `0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding: Option<f64>,
     /// The vertical padding in pixels between symbol legend entries.
     ///
     /// __Default value:__ `2`.
     #[serde(rename = "rowPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row_padding: Option<f64>,
     /// Border stroke color for the full legend.
     #[serde(rename = "strokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_color: Option<String>,
     /// Border stroke width for the full legend.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// The color of the legend symbol,
     #[serde(rename = "symbolFillColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_fill_color: Option<String>,
     /// Horizontal pixel offset for legend symbols.
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "symbolOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_offset: Option<f64>,
     /// Opacity of the legend symbols.
     #[serde(rename = "symbolOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_opacity: Option<f64>,
     /// The size of the legend symbol, in pixels.
     ///
     /// __Default value:__ `100`.
     #[serde(rename = "symbolSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_size: Option<f64>,
     /// Stroke color for legend symbols.
     #[serde(rename = "symbolStrokeColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_stroke_color: Option<String>,
     /// The width of the symbol's stroke.
     ///
     /// __Default value:__ `1.5`.
     #[serde(rename = "symbolStrokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_stroke_width: Option<f64>,
     /// Default shape type (such as "circle") for legend symbols.
     /// Can be one of ``"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
@@ -3899,9 +4473,11 @@ pub struct Legend {
     /// * __Default value:__ `"circle"`.
     /// *
     #[serde(rename = "symbolType")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub symbol_type: Option<String>,
     /// The desired number of tick values for quantitative legends.
     #[serde(rename = "tickCount")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_count: Option<f64>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -3921,43 +4497,53 @@ pub struct Legend {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// Horizontal text alignment for legend titles.
     ///
     /// __Default value:__ `"left"`.
     #[serde(rename = "titleAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_align: Option<Align>,
     /// Vertical text baseline for legend titles.
     ///
     /// __Default value:__ `"top"`.
     #[serde(rename = "titleBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_baseline: Option<TextBaseline>,
     /// The color of the legend title, can be in hex color code or regular color name.
     #[serde(rename = "titleColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_color: Option<String>,
     /// The font of the legend title.
     #[serde(rename = "titleFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font: Option<String>,
     /// The font size of the legend title.
     #[serde(rename = "titleFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_size: Option<f64>,
     /// The font weight of the legend title.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "titleFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_weight: Option<FontWeight>,
     /// Maximum allowed pixel width of axis titles.
     ///
     /// __Default value:__ `180`.
     #[serde(rename = "titleLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_limit: Option<f64>,
     /// Opacity of the legend title.
     #[serde(rename = "titleOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_opacity: Option<f64>,
     /// The padding, in pixels, between title and legend.
     ///
     /// __Default value:__ `5`.
     #[serde(rename = "titlePadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_padding: Option<f64>,
     /// The type of the legend. Use `"symbol"` to create a discrete legend and `"gradient"` for a
     /// continuous color gradient.
@@ -3965,18 +4551,22 @@ pub struct Legend {
     /// __Default value:__ `"gradient"` for non-binned quantitative fields and temporal fields;
     /// `"symbol"` otherwise.
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub legend_type: Option<LegendType>,
     /// Explicitly set the visible legend values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<SortElement>>,
     /// A non-positive integer indicating z-index of the legend.
     /// If zindex is 0, legend should be drawn behind all chart elements.
     /// To put them in front, use zindex = 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zindex: Option<f64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Scale {
     /// The logarithm base of the `log` scale (default `10`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub base: Option<f64>,
     /// If `true`, values that exceed the data domain are clamped to either the minimum or
     /// maximum range value
@@ -3984,6 +4574,7 @@ pub struct Scale {
     /// __Default value:__ derived from the [scale
     /// config](https://vega.github.io/vega-lite/docs/config.html#scale-config)'s `clamp` (`true`
     /// by default).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clamp: Option<bool>,
     /// Customized domain values.
     ///
@@ -4004,8 +4595,10 @@ pub struct Scale {
     /// The `selection` property can be used to [interactively
     /// determine](https://vega.github.io/vega-lite/docs/selection.html#scale-domains) the scale
     /// domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<DomainUnion>,
     /// The exponent of the `pow` scale.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exponent: Option<f64>,
     /// The interpolation method for range values. By default, a general interpolator for
     /// numbers, dates, strings and colors (in HCL space) is used. For color ranges, this
@@ -4022,6 +4615,7 @@ pub struct Scale {
     /// interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by default,
     /// you have to set the scale `type` to other quantitative scale type such as `"linear"` to
     /// customize `interpolate`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<InterpolateUnion>,
     /// Extending the domain so that it starts and ends on nice round values. This method
     /// typically modifies the scale’s domain, and may only extend the bounds to the nearest
@@ -4042,6 +4636,7 @@ pub struct Scale {
     /// snap to quarter (Jan, Apr, Jul, Oct) boundaries.
     ///
     /// __Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nice: Option<NiceUnion>,
     /// For _[continuous](https://vega.github.io/vega-lite/docs/scale.html#continuous)_ scales,
     /// expands the scale domain to accommodate the specified number of pixels on each of the
@@ -4058,6 +4653,7 @@ pub struct Scale {
     /// __Default value:__ For _continuous_ scales, derived from the [scale
     /// config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `continuousPadding`.
     /// For _band and point_ scales, see `paddingInner` and `paddingOuter`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding: Option<f64>,
     /// The inner padding (spacing) within each band step of band scales, as a fraction of the
     /// step size. This value must lie in the range [0,1].
@@ -4068,6 +4664,7 @@ pub struct Scale {
     /// __Default value:__ derived from the [scale
     /// config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `bandPaddingInner`.
     #[serde(rename = "paddingInner")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding_inner: Option<f64>,
     /// The outer padding (spacing) at the ends of the range of band and point scales,
     /// as a fraction of the step size. This value must lie in the range [0,1].
@@ -4076,6 +4673,7 @@ pub struct Scale {
     /// config](https://vega.github.io/vega-lite/docs/scale.html#config)'s `bandPaddingOuter` for
     /// band scales and `pointPadding` for point scales.
     #[serde(rename = "paddingOuter")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub padding_outer: Option<f64>,
     /// The range of the scale. One of:
     ///
@@ -4104,6 +4702,7 @@ pub struct Scale {
     /// [size](https://vega.github.io/vega-lite/docs/size.html) (`width` and `height`) or via
     /// [range steps and paddings properties](#range-step) for [band](#band) and [point](#point)
     /// scales.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub range: Option<ScaleRange>,
     /// The distance between the starts of adjacent bands or points in
     /// [band](https://vega.github.io/vega-lite/docs/scale.html#band) and
@@ -4123,11 +4722,13 @@ pub struct Scale {
     /// than `width` or `height`, the rangeStep might become less than one pixel and the mark
     /// might not appear correctly.
     #[serde(rename = "rangeStep")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub range_step: Option<f64>,
     /// If `true`, rounds numeric output values to integers. This can be helpful for snapping to
     /// the pixel grid.
     ///
     /// __Default value:__ `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub round: Option<bool>,
     /// A string indicating a color
     /// [scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme) name (e.g.,
@@ -4142,6 +4743,7 @@ pub struct Scale {
     ///
     /// For the full list of supported schemes, please refer to the [Vega
     /// Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scheme: Option<Scheme>,
     /// The type of scale.  Vega-Lite supports the following categories of scale types:
     ///
@@ -4173,6 +4775,7 @@ pub struct Scale {
     /// __Default value:__ please see the [scale type
     /// table](https://vega.github.io/vega-lite/docs/scale.html#type).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale_type: Option<ScaleType>,
     /// If `true`, ensures that a zero baseline value is included in the scale domain.
     ///
@@ -4180,6 +4783,7 @@ pub struct Scale {
     /// and no custom `domain` is provided; `false` otherwise.
     ///
     /// __Note:__ Log, time, and utc scales do not support `zero`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zero: Option<bool>,
 }
 
@@ -4188,17 +4792,20 @@ pub struct DomainClass {
     /// The field name to extract selected values for, when a selection is
     /// [projected](https://vega.github.io/vega-lite/docs/project.html)
     /// over multiple fields or encodings.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     /// The name of a selection.
     pub selection: String,
     /// The encoding channel to extract selected values for, when a selection is
     /// [projected](https://vega.github.io/vega-lite/docs/project.html)
     /// over multiple fields or encodings.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ScaleInterpolateParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gamma: Option<f64>,
     #[serde(rename = "type")]
     pub scale_interpolate_params_type: ScaleInterpolateParamsType,
@@ -4215,10 +4822,12 @@ pub struct SchemeParams {
     /// The number of colors to use in the scheme. This can be useful for scale types such as
     /// `"quantize"`, which use the length of the scale range to determine the number of discrete
     /// bins for the scale domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<f64>,
     /// For sequential and diverging schemes only, determines the extent of the color range to
     /// use. For example `[0.2, 1]` will rescale the color scheme such that color values in the
     /// range _[0, 0.2)_ are excluded from the scheme.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<Vec<f64>>,
     /// A color scheme name for sequential/ordinal scales (e.g., `"category10"` or `"viridis"`).
     ///
@@ -4234,6 +4843,7 @@ pub struct EncodingSortField {
     ///
     /// __Default value:__ If unspecified, defaults to the field specified in the outer data
     /// reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to
     /// perform on the field prior to sorting (e.g., `"count"`, `"mean"` and `"median"`).
@@ -4245,6 +4855,7 @@ pub struct EncodingSortField {
     /// [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).
     pub op: AggregateOp,
     /// The sort order. One of `"ascending"` (default), `"descending"`, or `null` (no not sort).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<VgComparatorOrder>,
 }
 
@@ -4257,6 +4868,7 @@ pub struct FacetFieldDef {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4274,6 +4886,7 @@ pub struct FacetFieldDef {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4287,8 +4900,10 @@ pub struct FacetFieldDef {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// An object defining properties of a facet's header.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub header: Option<Header>,
     /// Sort order for the encoded field.
     ///
@@ -4312,6 +4927,7 @@ pub struct FacetFieldDef {
     /// __Default value:__ `"ascending"`
     ///
     /// __Note:__ `null` is not supported for `row` and `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Sort>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4319,6 +4935,7 @@ pub struct FacetFieldDef {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4338,6 +4955,7 @@ pub struct FacetFieldDef {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
@@ -4365,32 +4983,39 @@ pub struct Header {
     /// quantitative fields and from
     /// [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for
     /// temporal fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// The rotation angle of the header labels.
     ///
     /// __Default value:__ `0` for column header, `-90` for row header.
     #[serde(rename = "labelAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_angle: Option<f64>,
     /// The color of the header label, can be in hex color code or regular color name.
     #[serde(rename = "labelColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_color: Option<String>,
     /// The font of the header label.
     #[serde(rename = "labelFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font: Option<String>,
     /// The font size of the header label, in pixels.
     #[serde(rename = "labelFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_size: Option<f64>,
     /// The maximum length of the header label in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
     #[serde(rename = "labelLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_limit: Option<f64>,
     /// The orthogonal distance in pixels by which to displace the title from its position along
     /// the edge of the chart.
     ///
     /// __Default value:__ `10`
     #[serde(rename = "labelPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_padding: Option<f64>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4410,6 +5035,7 @@ pub struct Header {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`. For
     /// example, with an orientation of top these anchor positions map to a left-, center-, or
@@ -4425,42 +5051,51 @@ pub struct Header {
     /// [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite
     /// views, `anchor` is always `"start"`.
     #[serde(rename = "titleAnchor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_anchor: Option<String>,
     /// The rotation angle of the header title.
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "titleAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_angle: Option<f64>,
     /// Vertical text baseline for the header title. One of `"top"`, `"bottom"`, `"middle"`.
     ///
     /// __Default value:__ `"middle"`
     #[serde(rename = "titleBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_baseline: Option<TextBaseline>,
     /// Color of the header title, can be in hex color code or regular color name.
     #[serde(rename = "titleColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_color: Option<String>,
     /// Font of the header title. (e.g., `"Helvetica Neue"`).
     #[serde(rename = "titleFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font: Option<String>,
     /// Font size of the header title.
     #[serde(rename = "titleFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_size: Option<f64>,
     /// Font weight of the header title.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "titleFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_weight: Option<FontWeight>,
     /// The maximum length of the header title in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
     #[serde(rename = "titleLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_limit: Option<f64>,
     /// The orthogonal distance in pixels by which to displace the title from its position along
     /// the edge of the chart.
     ///
     /// __Default value:__ `10`
     #[serde(rename = "titlePadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_padding: Option<f64>,
 }
 
@@ -4485,6 +5120,7 @@ pub struct FieldDef {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4502,6 +5138,7 @@ pub struct FieldDef {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4515,6 +5152,7 @@ pub struct FieldDef {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4522,6 +5160,7 @@ pub struct FieldDef {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4541,6 +5180,7 @@ pub struct FieldDef {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
@@ -4570,6 +5210,7 @@ pub struct DefWithCondition {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4587,6 +5228,7 @@ pub struct DefWithCondition {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// One or more value definition(s) with a selection predicate.
     ///
@@ -4595,6 +5237,7 @@ pub struct DefWithCondition {
     /// since Vega-Lite only allows at most one encoded field per encoding channel.
     ///
     /// A field definition or one or more value definition(s) with a selection predicate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<HrefCondition>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4608,6 +5251,7 @@ pub struct DefWithCondition {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4615,6 +5259,7 @@ pub struct DefWithCondition {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4634,30 +5279,37 @@ pub struct DefWithCondition {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub def_with_condition_type: Option<Type>,
     /// A constant value in visual domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConditionalPredicateFieldDefClass {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
     /// A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of
     /// [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<SelectionOperand>,
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4675,6 +5327,7 @@ pub struct ConditionalPredicateFieldDefClass {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4688,6 +5341,7 @@ pub struct ConditionalPredicateFieldDefClass {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4695,6 +5349,7 @@ pub struct ConditionalPredicateFieldDefClass {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4714,12 +5369,14 @@ pub struct ConditionalPredicateFieldDefClass {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conditional_def_type: Option<Type>,
 }
 
@@ -4729,6 +5386,7 @@ pub struct OrderFieldDef {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4746,6 +5404,7 @@ pub struct OrderFieldDef {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4759,8 +5418,10 @@ pub struct OrderFieldDef {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// The sort order. One of `"ascending"` (default) or `"descending"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<VgComparatorOrder>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4768,6 +5429,7 @@ pub struct OrderFieldDef {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4787,6 +5449,7 @@ pub struct OrderFieldDef {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
@@ -4803,6 +5466,7 @@ pub struct OrderFieldDefClass {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4820,6 +5484,7 @@ pub struct OrderFieldDefClass {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4833,8 +5498,10 @@ pub struct OrderFieldDefClass {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// The sort order. One of `"ascending"` (default) or `"descending"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<VgComparatorOrder>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4842,6 +5509,7 @@ pub struct OrderFieldDefClass {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4861,15 +5529,18 @@ pub struct OrderFieldDefClass {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub def_type: Option<Type>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
@@ -4893,6 +5564,7 @@ pub struct TextClass {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -4910,6 +5582,7 @@ pub struct TextClass {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// One or more value definition(s) with a selection predicate.
     ///
@@ -4918,6 +5591,7 @@ pub struct TextClass {
     /// since Vega-Lite only allows at most one encoded field per encoding channel.
     ///
     /// A field definition or one or more value definition(s) with a selection predicate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<TextCondition>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -4931,9 +5605,11 @@ pub struct TextClass {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text
     /// field. If not defined, this will be determined automatically.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -4941,6 +5617,7 @@ pub struct TextClass {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -4960,30 +5637,37 @@ pub struct TextClass {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_def_with_condition_type: Option<Type>,
     /// A constant value in visual domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConditionalPredicateTextFieldDefClass {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
     /// A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of
     /// [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<SelectionOperand>,
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -5001,6 +5685,7 @@ pub struct ConditionalPredicateTextFieldDefClass {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -5014,9 +5699,11 @@ pub struct ConditionalPredicateTextFieldDefClass {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text
     /// field. If not defined, this will be determined automatically.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -5024,6 +5711,7 @@ pub struct ConditionalPredicateTextFieldDefClass {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -5043,12 +5731,14 @@ pub struct ConditionalPredicateTextFieldDefClass {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conditional_def_type: Option<Type>,
 }
 
@@ -5058,6 +5748,7 @@ pub struct TextFieldDef {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -5075,6 +5766,7 @@ pub struct TextFieldDef {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -5088,9 +5780,11 @@ pub struct TextFieldDef {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text
     /// field. If not defined, this will be determined automatically.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -5098,6 +5792,7 @@ pub struct TextFieldDef {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -5117,6 +5812,7 @@ pub struct TextFieldDef {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
@@ -5144,6 +5840,7 @@ pub struct TextDefWithCondition {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -5161,6 +5858,7 @@ pub struct TextDefWithCondition {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// One or more value definition(s) with a selection predicate.
     ///
@@ -5169,6 +5867,7 @@ pub struct TextDefWithCondition {
     /// since Vega-Lite only allows at most one encoded field per encoding channel.
     ///
     /// A field definition or one or more value definition(s) with a selection predicate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<TextCondition>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -5182,9 +5881,11 @@ pub struct TextDefWithCondition {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// The [formatting pattern](https://vega.github.io/vega-lite/docs/format.html) for a text
     /// field. If not defined, this will be determined automatically.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -5192,6 +5893,7 @@ pub struct TextDefWithCondition {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -5211,14 +5913,17 @@ pub struct TextDefWithCondition {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text_def_with_condition_type: Option<Type>,
     /// A constant value in visual domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
@@ -5233,12 +5938,14 @@ pub struct XClass {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// An object defining properties of axis's gridlines, ticks and labels.
     /// If `null`, the axis for the encoding channel will be removed.
     ///
     /// __Default value:__ If undefined, default [axis
     /// properties](https://vega.github.io/vega-lite/docs/axis.html) are applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis: Option<Axis>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -5256,6 +5963,7 @@ pub struct XClass {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -5269,12 +5977,14 @@ pub struct XClass {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// An object defining the properties of the Impute Operation to be applied.
     /// The field value of the other positional channel is taken as `key` of the `Impute`
     /// Operation.
     /// The field of the `color` channel if specified is used as `groupby` of the `Impute`
     /// Operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub impute: Option<ImputeParams>,
     /// An object defining properties of the channel's scale, which is the function that
     /// transforms values in the data domain (numbers, dates, strings, etc) to visual values
@@ -5285,6 +5995,7 @@ pub struct XClass {
     ///
     /// __Default value:__ If undefined, default [scale
     /// properties](https://vega.github.io/vega-lite/docs/scale.html) are applied.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<Scale>,
     /// Sort order for the encoded field.
     ///
@@ -5308,6 +6019,7 @@ pub struct XClass {
     /// __Default value:__ `"ascending"`
     ///
     /// __Note:__ `null` is not supported for `row` and `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Sort>,
     /// Type of stacking offset if the field should be stacked.
     /// `stack` is only applicable for `x` and `y` channels with continuous domains.
@@ -5330,6 +6042,7 @@ pub struct XClass {
     /// (2) the stacked measure channel (x or y) has a linear scale;
     /// (3) At least one of non-position channels mapped to an unaggregated field that is
     /// different from x and y.  Otherwise, `null` by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stack: Option<StackOffset>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -5337,6 +6050,7 @@ pub struct XClass {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -5356,15 +6070,18 @@ pub struct XClass {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub def_type: Option<Type>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
@@ -5376,24 +6093,29 @@ pub struct Axis {
     ///
     /// __Default value:__ `0.5`
     #[serde(rename = "bandPosition")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub band_position: Option<f64>,
     /// A boolean flag indicating if the domain (the axis baseline) should be included as part of
     /// the axis.
     ///
     /// __Default value:__ `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domain: Option<bool>,
     /// Color of axis domain line.
     ///
     /// __Default value:__ `"gray"`.
     #[serde(rename = "domainColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domain_color: Option<String>,
     /// Opacity of the axis domain line.
     #[serde(rename = "domainOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domain_opacity: Option<f64>,
     /// Stroke width of axis domain line
     ///
     /// __Default value:__ `1`
     #[serde(rename = "domainWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domain_width: Option<f64>,
     /// The formatting pattern for labels. This is D3's [number format
     /// pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and D3's
@@ -5408,43 +6130,52 @@ pub struct Axis {
     /// quantitative fields and from
     /// [timeFormat](https://vega.github.io/vega-lite/docs/config.html#format) config for
     /// temporal fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     /// A boolean flag indicating if grid lines should be included as part of the axis
     ///
     /// __Default value:__ `true` for [continuous
     /// scales](https://vega.github.io/vega-lite/docs/scale.html#continuous) that are not binned;
     /// otherwise, `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid: Option<bool>,
     /// Color of gridlines.
     ///
     /// __Default value:__ `"lightGray"`.
     #[serde(rename = "gridColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid_color: Option<String>,
     /// The offset (in pixels) into which to begin drawing with the grid dash array.
     #[serde(rename = "gridDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid_dash: Option<Vec<f64>>,
     /// The stroke opacity of grid (value between [0,1])
     ///
     /// __Default value:__ `1`
     #[serde(rename = "gridOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid_opacity: Option<f64>,
     /// The grid width, in pixels.
     ///
     /// __Default value:__ `1`
     #[serde(rename = "gridWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grid_width: Option<f64>,
     /// Horizontal text alignment of axis tick labels, overriding the default setting for the
     /// current axis orientation.
     #[serde(rename = "labelAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_align: Option<Align>,
     /// The rotation angle of the axis labels.
     ///
     /// __Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.
     #[serde(rename = "labelAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_angle: Option<f64>,
     /// Vertical text baseline of axis tick labels, overriding the default setting for the
     /// current axis orientation. Can be `"top"`, `"middle"`, `"bottom"`, or `"alphabetic"`.
     #[serde(rename = "labelBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_baseline: Option<TextBaseline>,
     /// Indicates if labels should be hidden if they exceed the axis range. If `false` (the
     /// default) no bounds overlap analysis is performed. If `true`, labels will be hidden if
@@ -5454,9 +6185,11 @@ pub struct Axis {
     ///
     /// __Default value:__ `false`.
     #[serde(rename = "labelBound")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_bound: Option<Label>,
     /// The color of the tick label, can be in hex color code or regular color name.
     #[serde(rename = "labelColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_color: Option<String>,
     /// Indicates if the first and last axis labels should be aligned flush with the scale range.
     /// Flush alignment for a horizontal axis will left-align the first label and right-align the
@@ -5468,6 +6201,7 @@ pub struct Axis {
     ///
     /// __Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.
     #[serde(rename = "labelFlush")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_flush: Option<Label>,
     /// Indicates the number of pixels by which to offset flush-adjusted labels. For example, a
     /// value of `2` will push flush-adjusted labels 2 pixels outward from the center of the
@@ -5475,23 +6209,29 @@ pub struct Axis {
     ///
     /// __Default value:__ `0`.
     #[serde(rename = "labelFlushOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_flush_offset: Option<f64>,
     /// The font of the tick label.
     #[serde(rename = "labelFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font: Option<String>,
     /// The font size of the label, in pixels.
     #[serde(rename = "labelFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_size: Option<f64>,
     /// Font weight of axis tick labels.
     #[serde(rename = "labelFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_font_weight: Option<FontWeight>,
     /// Maximum allowed pixel width of axis tick labels.
     ///
     /// __Default value:__ `180`
     #[serde(rename = "labelLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_limit: Option<f64>,
     /// The opacity of the labels.
     #[serde(rename = "labelOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_opacity: Option<f64>,
     /// The strategy to use for resolving overlap of axis labels. If `false` (the default), no
     /// overlap reduction is attempted. If set to `true` or `"parity"`, a strategy of removing
@@ -5502,27 +6242,32 @@ pub struct Axis {
     /// __Default value:__ `true` for non-nominal fields with non-log scales; `"greedy"` for log
     /// scales; otherwise `false`.
     #[serde(rename = "labelOverlap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_overlap: Option<LabelOverlap>,
     /// The padding, in pixels, between axis and text labels.
     ///
     /// __Default value:__ `2`
     #[serde(rename = "labelPadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label_padding: Option<f64>,
     /// A boolean flag indicating if labels should be included as part of the axis.
     ///
     /// __Default value:__ `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<bool>,
     /// The maximum extent in pixels that axis ticks and labels should use. This determines a
     /// maximum offset value for axis titles.
     ///
     /// __Default value:__ `undefined`.
     #[serde(rename = "maxExtent")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_extent: Option<f64>,
     /// The minimum extent in pixels that axis ticks and labels should use. This determines a
     /// minimum offset value for axis titles.
     ///
     /// __Default value:__ `30` for y-axis; `undefined` for x-axis.
     #[serde(rename = "minExtent")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_extent: Option<f64>,
     /// The offset, in pixels, by which to displace the axis from the edge of the enclosing group
     /// or data rectangle.
@@ -5530,55 +6275,66 @@ pub struct Axis {
     /// __Default value:__ derived from the [axis
     /// config](https://vega.github.io/vega-lite/docs/config.html#facet-scale-config)'s `offset`
     /// (`0` by default)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
     /// The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The
     /// orientation can be used to further specialize the axis type (e.g., a y axis oriented for
     /// the right edge of the chart).
     ///
     /// __Default value:__ `"bottom"` for x-axes and `"left"` for y-axes.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<LegendOrient>,
     /// The anchor position of the axis in pixels. For x-axes with top or bottom orientation,
     /// this sets the axis group x coordinate. For y-axes with left or right orientation, this
     /// sets the axis group y coordinate.
     ///
     /// __Default value__: `0`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub position: Option<f64>,
     /// The color of the axis's tick.
     ///
     /// __Default value:__ `"gray"`
     #[serde(rename = "tickColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_color: Option<String>,
     /// A desired number of ticks, for axes visualizing quantitative scales. The resulting number
     /// may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the
     /// underlying scale's range.
     #[serde(rename = "tickCount")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_count: Option<f64>,
     /// Boolean flag indicating if an extra axis tick should be added for the initial position of
     /// the axis. This flag is useful for styling axes for `band` scales such that ticks are
     /// placed on band boundaries rather in the middle of a band. Use in conjunction with
     /// `"bandPostion": 1` and an axis `"padding"` value of `0`.
     #[serde(rename = "tickExtra")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_extra: Option<bool>,
     /// Position offset in pixels to apply to ticks, labels, and gridlines.
     #[serde(rename = "tickOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_offset: Option<f64>,
     /// Opacity of the ticks.
     #[serde(rename = "tickOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_opacity: Option<f64>,
     /// Boolean flag indicating if pixel position values should be rounded to the nearest
     /// integer.
     ///
     /// __Default value:__ `true`
     #[serde(rename = "tickRound")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_round: Option<bool>,
     /// Boolean value that determines whether the axis should include ticks.
     ///
     /// __Default value:__ `true`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ticks: Option<bool>,
     /// The size in pixels of axis ticks.
     ///
     /// __Default value:__ `5`
     #[serde(rename = "tickSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_size: Option<f64>,
     /// A desired step size for ticks. This property will generate the corresponding `tickCount`
     /// and `values`. It can be useful for [data that are binned before importing into
@@ -5586,11 +6342,13 @@ pub struct Axis {
     ///
     /// __Default value__: `undefined`
     #[serde(rename = "tickStep")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_step: Option<f64>,
     /// The width, in pixels, of ticks.
     ///
     /// __Default value:__ `1`
     #[serde(rename = "tickWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tick_width: Option<f64>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -5610,46 +6368,60 @@ pub struct Axis {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// Horizontal text alignment of axis titles.
     #[serde(rename = "titleAlign")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_align: Option<Align>,
     /// Angle in degrees of axis titles.
     #[serde(rename = "titleAngle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_angle: Option<f64>,
     /// Vertical text baseline for axis titles.
     #[serde(rename = "titleBaseline")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_baseline: Option<TextBaseline>,
     /// Color of the title, can be in hex color code or regular color name.
     #[serde(rename = "titleColor")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_color: Option<String>,
     /// Font of the title. (e.g., `"Helvetica Neue"`).
     #[serde(rename = "titleFont")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font: Option<String>,
     /// Font size of the title.
     #[serde(rename = "titleFontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_size: Option<f64>,
     /// Font weight of the title.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "titleFontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_font_weight: Option<FontWeight>,
     /// Maximum allowed pixel width of axis titles.
     #[serde(rename = "titleLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_limit: Option<f64>,
     /// Opacity of the axis title.
     #[serde(rename = "titleOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_opacity: Option<f64>,
     /// The padding, in pixels, between title and axis.
     #[serde(rename = "titlePadding")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_padding: Option<f64>,
     /// X-coordinate of the axis title relative to the axis group.
     #[serde(rename = "titleX")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_x: Option<f64>,
     /// Y-coordinate of the axis title relative to the axis group.
     #[serde(rename = "titleY")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title_y: Option<f64>,
     /// Explicitly set the visible axis tick values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub values: Option<Vec<SortElement>>,
     /// A non-positive integer indicating z-index of the axis.
     /// If zindex is 0, axes should be drawn behind all chart elements.
@@ -5657,6 +6429,7 @@ pub struct Axis {
     ///
     /// __Default value:__ `1` (in front of the marks) for actual axis and `0` (behind the marks)
     /// for grids.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zindex: Option<f64>,
 }
 
@@ -5675,6 +6448,7 @@ pub struct ImputeParams {
     /// object.
     ///
     /// __Default value:__:  `[null, null]` indicating that the window includes all objects.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub frame: Option<Vec<Option<f64>>>,
     /// Defines the key values that should be considered for imputation.
     /// An array of key values or an object defining a [number
@@ -5686,13 +6460,16 @@ pub struct ImputeParams {
     /// imputed, or vice versa.
     ///
     /// If there is no impute grouping, this property _must_ be specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub keyvals: Option<Keyvals>,
     /// The imputation method to use for the field value of imputed data objects.
     /// One of `value`, `mean`, `median`, `max` or `min`.
     ///
     /// __Default value:__  `"value"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<ImputeMethod>,
     /// The field value to use when the imputation `method` is `"value"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<serde_json::Value>,
 }
 
@@ -5700,9 +6477,11 @@ pub struct ImputeParams {
 pub struct ImputeSequence {
     /// The starting value of the sequence.
     /// __Default value:__ `0`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start: Option<f64>,
     /// The step value between sequence entries.
     /// __Default value:__ `1` or `-1` if `stop < start`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub step: Option<f64>,
     /// The ending value(exclusive) of the sequence.
     pub stop: f64,
@@ -5735,6 +6514,7 @@ pub struct X2Class {
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
     ///
     /// __Default value:__ `undefined` (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<AggregateOp>,
     /// A flag for binning a `quantitative` field, [an object defining binning
     /// parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that
@@ -5752,6 +6532,7 @@ pub struct X2Class {
     /// [`tickStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<Bin>,
     /// __Required.__ A string defining the name of the field from which to pull a data value
     /// or an object defining iterated values from the
@@ -5765,6 +6546,7 @@ pub struct X2Class {
     /// documentation](https://vega.github.io/vega-lite/docs/field.html).
     ///
     /// __Note:__ `field` is not required if `aggregate` is `count`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<Field>,
     /// Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.
     /// or [a temporal field that gets casted as
@@ -5772,6 +6554,7 @@ pub struct X2Class {
     ///
     /// __Default value:__ `undefined` (None)
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A title for the field. If `null`, the title will be removed.
     ///
@@ -5791,15 +6574,18 @@ pub struct X2Class {
     ///
     /// 2) If both field definition's `title` and axis, header, or legend `title` are defined,
     /// axis/header/legend title will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// The encoded field's type of measurement (`"quantitative"`, `"temporal"`, `"ordinal"`, or
     /// `"nominal"`).
     /// It can also be a `"geojson"` type for encoding
     /// ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).
     #[serde(rename = "type")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub def_type: Option<Type>,
     /// A constant value in visual domain (e.g., `"red"` / "#0099ff" for color, values between
     /// `0` to `1` for opacity).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<Value>,
 }
 
@@ -5808,8 +6594,10 @@ pub struct X2Class {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FacetMapping {
     /// Horizontal facets for trellis plots.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<FacetFieldDef>,
     /// Vertical facets for trellis plots.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<FacetFieldDef>,
 }
 
@@ -5821,13 +6609,16 @@ pub struct FacetMapping {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SpecClass {
     /// An object describing the data source
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Data>,
     /// Description of this mark for commenting purpose.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// A shared key-value mapping between encoding channels and definition of fields in the
     /// underlying layers.
     ///
     /// A key-value mapping between encoding channels and definition of fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<Encoding>,
     /// The height of a visualization.
     ///
@@ -5852,6 +6643,7 @@ pub struct SpecClass {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<f64>,
     /// Layer or single view specifications to be layered.
     ///
@@ -5859,14 +6651,17 @@ pub struct SpecClass {
     /// layering facet specifications is not allowed. Instead, use the [facet
     /// operator](https://vega.github.io/vega-lite/docs/facet.html) and place a layer inside a
     /// facet.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub layer: Option<Vec<LayerSpec>>,
     /// Name of the visualization for later reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// An object defining properties of the geographic projection shared by underlying layers.
     ///
     /// An object defining properties of geographic projection, which will be applied to `shape`
     /// path for `"geoshape"` marks
     /// and to `latitude` and `"longitude"` channels for other marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projection: Option<Projection>,
     /// Scale, axis, and legend resolutions for layers.
     ///
@@ -5877,10 +6672,13 @@ pub struct SpecClass {
     /// Scale, axis, and legend resolutions for vertically concatenated charts.
     ///
     /// Scale, axis, and legend resolutions for horizontally concatenated charts.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Resolve>,
     /// Title for the plot.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
     /// An array of data transformations such as filter and new field calculation.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transform: Option<Vec<Transform>>,
     /// The width of a visualization.
     ///
@@ -5908,13 +6706,16 @@ pub struct SpecClass {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<f64>,
     /// A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
     /// `"line"`,
     /// `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition
     /// object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<AnyMark>,
     /// A key-value mapping between selection names and definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<HashMap<String, SelectionDef>>,
     /// The alignment to apply to grid rows and columns.
     /// The supported string values are `"all"`, `"each"`, and `"none"`.
@@ -5931,6 +6732,7 @@ pub struct SpecClass {
     /// used to supply different alignments for rows and columns.
     ///
     /// __Default value:__ `"all"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<AlignUnion>,
     /// The bounds calculation method to use for determining the extent of a sub-plot. One of
     /// `full` (the default) or `flush`.
@@ -5942,6 +6744,7 @@ pub struct SpecClass {
     /// or legends into a uniform grid structure.
     ///
     /// __Default value:__ `"full"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Bounds>,
     /// Boolean flag indicating if subviews should be centered relative to their respective rows
     /// or columns.
@@ -5955,9 +6758,11 @@ pub struct SpecClass {
     /// or columns.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub center: Option<Center>,
     /// An object that describes mappings between `row` and `column` channels and their field
     /// definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub facet: Option<FacetMapping>,
     /// The spacing in pixels between sub-views of the composition operator.
     /// An object of the form `{"row": number, "column": number}` can be used to set
@@ -5968,15 +6773,20 @@ pub struct SpecClass {
     /// The spacing in pixels between sub-views of the concat operator.
     ///
     /// __Default value__: `10`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spacing: Option<Spacing>,
     /// A specification of the view that gets faceted.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<Box<SpecClass>>,
     /// An object that describes what fields should be repeated into views that are laid out as a
     /// `row` or `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub repeat: Option<Repeat>,
     /// A list of views that should be concatenated and put into a column.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vconcat: Option<Vec<Spec>>,
     /// A list of views that should be concatenated and put into a row.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hconcat: Option<Vec<Spec>>,
 }
 
@@ -5986,13 +6796,16 @@ pub struct SpecClass {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Spec {
     /// An object describing the data source
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Data>,
     /// Description of this mark for commenting purpose.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// A key-value mapping between encoding channels and definition of fields.
     ///
     /// A shared key-value mapping between encoding channels and definition of fields in the
     /// underlying layers.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<Encoding>,
     /// The height of a visualization.
     ///
@@ -6017,25 +6830,32 @@ pub struct Spec {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<f64>,
     /// A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
     /// `"line"`,
     /// `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition
     /// object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<AnyMark>,
     /// Name of the visualization for later reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// An object defining properties of geographic projection, which will be applied to `shape`
     /// path for `"geoshape"` marks
     /// and to `latitude` and `"longitude"` channels for other marks.
     ///
     /// An object defining properties of the geographic projection shared by underlying layers.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projection: Option<Projection>,
     /// A key-value mapping between selection names and definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<HashMap<String, SelectionDef>>,
     /// Title for the plot.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
     /// An array of data transformations such as filter and new field calculation.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transform: Option<Vec<Transform>>,
     /// The width of a visualization.
     ///
@@ -6063,6 +6883,7 @@ pub struct Spec {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<f64>,
     /// Layer or single view specifications to be layered.
     ///
@@ -6070,6 +6891,7 @@ pub struct Spec {
     /// layering facet specifications is not allowed. Instead, use the [facet
     /// operator](https://vega.github.io/vega-lite/docs/facet.html) and place a layer inside a
     /// facet.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub layer: Option<Vec<LayerSpec>>,
     /// Scale, axis, and legend resolutions for layers.
     ///
@@ -6080,6 +6902,7 @@ pub struct Spec {
     /// Scale, axis, and legend resolutions for vertically concatenated charts.
     ///
     /// Scale, axis, and legend resolutions for horizontally concatenated charts.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Resolve>,
     /// The alignment to apply to grid rows and columns.
     /// The supported string values are `"all"`, `"each"`, and `"none"`.
@@ -6096,6 +6919,7 @@ pub struct Spec {
     /// used to supply different alignments for rows and columns.
     ///
     /// __Default value:__ `"all"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<AlignUnion>,
     /// The bounds calculation method to use for determining the extent of a sub-plot. One of
     /// `full` (the default) or `flush`.
@@ -6107,6 +6931,7 @@ pub struct Spec {
     /// or legends into a uniform grid structure.
     ///
     /// __Default value:__ `"full"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bounds: Option<Bounds>,
     /// Boolean flag indicating if subviews should be centered relative to their respective rows
     /// or columns.
@@ -6120,9 +6945,11 @@ pub struct Spec {
     /// or columns.
     ///
     /// __Default value:__ `false`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub center: Option<Center>,
     /// An object that describes mappings between `row` and `column` channels and their field
     /// definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub facet: Option<FacetMapping>,
     /// The spacing in pixels between sub-views of the composition operator.
     /// An object of the form `{"row": number, "column": number}` can be used to set
@@ -6133,15 +6960,20 @@ pub struct Spec {
     /// The spacing in pixels between sub-views of the concat operator.
     ///
     /// __Default value__: `10`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spacing: Option<Spacing>,
     /// A specification of the view that gets faceted.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub spec: Option<SpecClass>,
     /// An object that describes what fields should be repeated into views that are laid out as a
     /// `row` or `column`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub repeat: Option<Repeat>,
     /// A list of views that should be concatenated and put into a column.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vconcat: Option<Vec<Spec>>,
     /// A list of views that should be concatenated and put into a row.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hconcat: Option<Vec<Spec>>,
 }
 
@@ -6151,13 +6983,16 @@ pub struct Spec {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LayerSpec {
     /// An object describing the data source
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<Data>,
     /// Description of this mark for commenting purpose.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// A shared key-value mapping between encoding channels and definition of fields in the
     /// underlying layers.
     ///
     /// A key-value mapping between encoding channels and definition of fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<LayerEncoding>,
     /// The height of a visualization.
     ///
@@ -6182,6 +7017,7 @@ pub struct LayerSpec {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub height: Option<f64>,
     /// Layer or single view specifications to be layered.
     ///
@@ -6189,20 +7025,26 @@ pub struct LayerSpec {
     /// layering facet specifications is not allowed. Instead, use the [facet
     /// operator](https://vega.github.io/vega-lite/docs/facet.html) and place a layer inside a
     /// facet.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub layer: Option<Vec<LayerSpec>>,
     /// Name of the visualization for later reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// An object defining properties of the geographic projection shared by underlying layers.
     ///
     /// An object defining properties of geographic projection, which will be applied to `shape`
     /// path for `"geoshape"` marks
     /// and to `latitude` and `"longitude"` channels for other marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub projection: Option<Projection>,
     /// Scale, axis, and legend resolutions for layers.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<Resolve>,
     /// Title for the plot.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<Title>,
     /// An array of data transformations such as filter and new field calculation.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transform: Option<Vec<Transform>>,
     /// The width of a visualization.
     ///
@@ -6230,13 +7072,16 @@ pub struct LayerSpec {
     ///
     /// __See also:__ The documentation for [width and
     /// height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub width: Option<f64>,
     /// A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`,
     /// `"line"`,
     /// `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition
     /// object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<AnyMark>,
     /// A key-value mapping between selection names and definitions.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection: Option<HashMap<String, SelectionDef>>,
 }
 
@@ -6261,9 +7106,11 @@ pub struct LayerEncoding {
     /// channel will be ignored.
     /// 2) See the scale documentation for more information about customizing [color
     /// scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<MarkPropDefWithCondition>,
     /// Additional levels of detail for grouping data in aggregate views and
     /// in line, trail, and area marks without mapping data to a specific visual channel.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<Detail>,
     /// Fill color of the marks.
     /// __Default value:__ If undefined, the default color depends on [mark
@@ -6271,27 +7118,35 @@ pub struct LayerEncoding {
     ///
     /// _Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both
     /// fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<MarkPropDefWithCondition>,
     /// A URL to load upon mouse click.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<DefWithCondition>,
     /// A data field to use as a unique key for data binding. When a visualization’s data is
     /// updated, the key value will be used to match data elements to existing mark instances.
     /// Use a key channel to enable object constancy for transitions over dynamic data.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<FieldDef>,
     /// Latitude position of geographically projected marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub latitude: Option<FieldDef>,
     /// Latitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`, and
     /// `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub latitude2: Option<FieldDef>,
     /// Longitude position of geographically projected marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub longitude: Option<FieldDef>,
     /// Longitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`,
     /// and  `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub longitude2: Option<FieldDef>,
     /// Opacity of the marks – either can be a value or a range.
     ///
     /// __Default value:__ If undefined, the default opacity depends on [mark
     /// config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<MarkPropDefWithCondition>,
     /// Order of the marks.
     /// - For stacked marks, this `order` channel encodes [stack
@@ -6305,6 +7160,7 @@ pub struct LayerEncoding {
     ///
     /// __Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating
     /// additional aggregation grouping.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<Order>,
     /// For `point` marks the supported values are
     /// `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
@@ -6314,6 +7170,7 @@ pub struct LayerEncoding {
     /// __Default value:__ If undefined, the default shape depends on [mark
     /// config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape`
     /// property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<MarkPropDefWithCondition>,
     /// Size of the mark.
     /// - For `"point"`, `"square"` and `"circle"`, – the symbol size, or pixel area of the mark.
@@ -6321,6 +7178,7 @@ pub struct LayerEncoding {
     /// - For `"text"` – the text's font size.
     /// - Size is unsupported for `"line"`, `"area"`, and `"rect"`. (Use `"trail"` instead of
     /// line with varying size)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<MarkPropDefWithCondition>,
     /// Stroke color of the marks.
     /// __Default value:__ If undefined, the default color depends on [mark
@@ -6328,28 +7186,37 @@ pub struct LayerEncoding {
     ///
     /// _Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both
     /// stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<MarkPropDefWithCondition>,
     /// Text of the `text` mark.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextClass>,
     /// The tooltip text to show upon mouse hover.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<EncodingTooltip>,
     /// X coordinates of the marks, or width of horizontal `"bar"` and `"area"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x: Option<XClass>,
     /// X2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x2: Option<X2Class>,
     /// Y coordinates of the marks, or height of vertical `"bar"` and `"area"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y: Option<XClass>,
     /// Y2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y2: Option<X2Class>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BoxPlotDefClass {
     #[serde(rename = "box")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub def_box: Option<BooleanOrMarkConfig>,
     /// Whether a composite mark be clipped to the enclosing group’s width and height.
     ///
     /// Whether a mark be clipped to the enclosing group’s width and height.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clip: Option<bool>,
     /// Default color.  Note that `fill` and `stroke` have higher precedence than `color` and
     /// will override `color`.
@@ -6358,6 +7225,7 @@ pub struct BoxPlotDefClass {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// The extent of the whiskers. Available options include:
     /// - `"min-max"`: min and max are the lower and upper whiskers respectively.
@@ -6386,7 +7254,9 @@ pub struct BoxPlotDefClass {
     /// - `"iqr"`: Extend the band to the q1 and q3.
     ///
     /// __Default value:__ `"stderr"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extent: Option<BoxPlotDefExtent>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub median: Option<BooleanOrMarkConfig>,
     /// The opacity (value between [0,1]) of the mark.
     ///
@@ -6394,6 +7264,7 @@ pub struct BoxPlotDefClass {
     ///
     /// __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or
     /// `square` marks or layered `bar` charts and `1` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<f64>,
     /// Orientation of the box plot.  This is normally automatically determined based on types of
     /// fields on x and y channels. However, an explicit `orient` be specified when the
@@ -6417,8 +7288,11 @@ pub struct BoxPlotDefClass {
     /// if `config.sortLineBy` is not specified.
     /// For stacked charts, this is always determined by the orientation of the stack;
     /// therefore explicitly specified value will be ignored.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<Orient>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub outliers: Option<BooleanOrMarkConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rule: Option<BooleanOrMarkConfig>,
     /// Size of the box and median tick of a box plot
     ///
@@ -6432,7 +7306,9 @@ pub struct BoxPlotDefClass {
     /// __Default value:__ `30` for point, circle, square marks; `rangeStep` - 1 for bar marks
     /// with discrete dimensions; `5` for bar marks with continuous dimensions; `11` for text
     /// marks.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ticks: Option<BooleanOrMarkConfig>,
     /// The mark type. This could a primitive mark type
     /// (one of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
@@ -6444,7 +7320,9 @@ pub struct BoxPlotDefClass {
     /// `"area"`, `"point"`, `"geoshape"`, `"rule"`, and `"text"`.
     #[serde(rename = "type")]
     pub def_type: BoxPlot,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub band: Option<BooleanOrMarkConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub borders: Option<BooleanOrMarkConfig>,
     /// The line interpolation method for the error band. One of the following:
     /// - `"linear"`: piecewise linear segments, as in a polyline.
@@ -6483,51 +7361,64 @@ pub struct BoxPlotDefClass {
     /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
     /// spline.
     /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interpolate: Option<Interpolate>,
     /// The tension parameter for the interpolation type of the error band.
     ///
     /// Depending on the interpolation type, sets the tension parameter (for line and area marks).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tension: Option<f64>,
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The rotation angle of the text, in degrees.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
     ///
     /// __Default value:__ `"middle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Offset between bars for binned field.  Ideal value for this is either 0 (Preferred by
     /// statisticians) or 1 (Vega-Lite Default, D3 example style).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "binSpacing")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin_spacing: Option<f64>,
     /// The radius in pixels of rounded rectangle corners.
     ///
     /// __Default value:__ `0`
     #[serde(rename = "cornerRadius")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub corner_radius: Option<f64>,
     /// The mouse cursor used over the mark. Any valid [CSS cursor
     /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
     /// The direction of the text. One of `"ltr"` (left-to-right) or `"rtl"` (right-to-left).
     /// This property determines on which side is truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"ltr"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dir: Option<Dir>,
     /// The horizontal offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dx: Option<f64>,
     /// The vertical offset, in pixels, between the text label and its anchor point. The offset
     /// is applied after rotation by the _angle_ property.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dy: Option<f64>,
     /// The ellipsis string for text truncated in response to the limit parameter.
     ///
     /// __Default value:__ `"…"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ellipsis: Option<String>,
     /// Default Fill Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<String>,
     /// Whether the mark's color should be used as fill color instead of stroke color.
     ///
@@ -6537,31 +7428,39 @@ pub struct BoxPlotDefClass {
     ///
     /// __Note:__ This property cannot be used in a [style
     /// config](https://vega.github.io/vega-lite/docs/mark.html#style-config).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filled: Option<bool>,
     /// The fill opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "fillOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill_opacity: Option<f64>,
     /// The typeface to set the text in (e.g., `"Helvetica Neue"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// The font size, in pixels.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// The font style (e.g., `"italic"`).
     #[serde(rename = "fontStyle")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_style: Option<FontStyle>,
     /// The font weight.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// A URL to load upon mouse click. If defined, the mark acts as a hyperlink.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
     /// The maximum length of the text mark in pixels. The text value will be automatically
     /// truncated if the rendered size exceeds the limit.
     ///
     /// __Default value:__ `0`, indicating no limit
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// A flag for overlaying line on top of area marks, or an object defining the properties of
     /// the overlayed lines.
@@ -6572,6 +7471,7 @@ pub struct BoxPlotDefClass {
     /// - If this value is `false`, no lines would be automatically added to area marks.
     ///
     /// __Default value:__ `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub line: Option<Line>,
     /// A flag for overlaying points on top of line or area marks, or an object defining the
     /// properties of the overlayed points.
@@ -6586,45 +7486,56 @@ pub struct BoxPlotDefClass {
     /// marks.
     ///
     /// __Default value:__ `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub point: Option<PointUnion>,
     /// Polar coordinate radial offset, in pixels, of the text label from the origin determined
     /// by the `x` and `y` properties.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub radius: Option<f64>,
     /// The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`,
     /// `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
     ///
     /// __Default value:__ `"circle"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<String>,
     /// Default Stroke Color.  This has higher precedence than `config.color`
     ///
     /// __Default value:__ (None)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<String>,
     /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
     ///
     /// __Default value:__ `"square"`
     #[serde(rename = "strokeCap")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_cap: Option<StrokeCap>,
     /// An array of alternating stroke, space lengths for creating dashed or dotted lines.
     #[serde(rename = "strokeDash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash: Option<Vec<f64>>,
     /// The offset (in pixels) into which to begin drawing with the stroke dash array.
     #[serde(rename = "strokeDashOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_dash_offset: Option<f64>,
     /// The stroke line join method. One of `"miter"`, `"round"` or `"bevel"`.
     ///
     /// __Default value:__ `"miter"`
     #[serde(rename = "strokeJoin")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_join: Option<StrokeJoin>,
     /// The miter limit at which to bevel a line join.
     #[serde(rename = "strokeMiterLimit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_miter_limit: Option<f64>,
     /// The stroke opacity (value between [0,1]).
     ///
     /// __Default value:__ `1`
     #[serde(rename = "strokeOpacity")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_opacity: Option<f64>,
     /// The stroke width, in pixels.
     #[serde(rename = "strokeWidth")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke_width: Option<f64>,
     /// A string or array of strings indicating the name of custom styles to apply to the mark. A
     /// style is a named collection of mark property defaults defined within the [style
@@ -6638,17 +7549,21 @@ pub struct BoxPlotDefClass {
     /// __Note:__ Any specified style will augment the default style. For example, a bar mark
     /// with `"style": "foo"` will receive from `config.style.bar` and `config.style.foo` (the
     /// specified style `"foo"` has higher precedence).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<Style>,
     /// Placeholder text if the `text` channel is not specified
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<String>,
     /// Polar coordinate angle, in radians, of the text label from the origin determined by the
     /// `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark
     /// `startAngle` and `endAngle` properties: angles are measured in radians, with `0`
     /// indicating "north".
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub theta: Option<f64>,
     /// Thickness of the tick mark.
     ///
     /// __Default value:__  `1`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub thickness: Option<f64>,
     /// The tooltip text string to show upon mouse hover or an object defining which fields
     /// should the tooltip be derived from.
@@ -6657,18 +7572,23 @@ pub struct BoxPlotDefClass {
     /// used.
     /// - If `tooltip` is `{"content": "data"}`, then all fields that appear in the highlighted
     /// data point will be used.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tooltip: Option<Tooltip>,
     /// Offset for x2-position.
     #[serde(rename = "x2Offset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x2_offset: Option<f64>,
     /// Offset for x-position.
     #[serde(rename = "xOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x_offset: Option<f64>,
     /// Offset for y2-position.
     #[serde(rename = "y2Offset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y2_offset: Option<f64>,
     /// Offset for y-position.
     #[serde(rename = "yOffset")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y_offset: Option<f64>,
 }
 
@@ -6686,36 +7606,55 @@ pub struct BoxPlotDefClass {
 /// Scale, axis, and legend resolutions for horizontally concatenated charts.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Resolve {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub axis: Option<AxisResolveMap>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub legend: Option<LegendResolveMap>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<ScaleResolveMap>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AxisResolveMap {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y: Option<ResolveMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct LegendResolveMap {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<ResolveMode>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ScaleResolveMap {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fill: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub opacity: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shape: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stroke: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub x: Option<ResolveMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub y: Option<ResolveMode>,
 }
 
@@ -6732,30 +7671,37 @@ pub struct SelectionDef {
     /// Establishes a two-way binding between the interval selection and the scales
     /// used within the same view. This allows a user to interactively pan and
     /// zoom the view.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bind: Option<SelectionDefBind>,
     /// By default, all data values are considered to lie within an empty selection.
     /// When set to `none`, empty selections contain no data values.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub empty: Option<VgLayoutAlign>,
     /// An array of encoding channels. The corresponding data field values
     /// must match for a data tuple to fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encodings: Option<Vec<SingleDefChannel>>,
     /// An array of field names whose values must match for a data tuple to
     /// fall within the selection.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<String>>,
     /// When true, an invisible voronoi diagram is computed to accelerate discrete
     /// selection. The data value _nearest_ the mouse cursor is added to the selection.
     ///
     /// See the [nearest transform](https://vega.github.io/vega-lite/docs/nearest.html)
     /// documentation for more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nearest: Option<bool>,
     /// A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or
     /// selector) that triggers the selection.
     /// For interval selections, the event stream must specify a [start and
     /// end](https://vega.github.io/vega/docs/event-streams/#between-filters).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub on: Option<serde_json::Value>,
     /// With layered and multi-view displays, a strategy that determines how
     /// selections' data queries are resolved when applied in a filter transform,
     /// conditional encoding rule, or scale domain.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resolve: Option<SelectionResolution>,
     #[serde(rename = "type")]
     pub selection_def_type: SelectionDefType,
@@ -6768,10 +7714,12 @@ pub struct SelectionDef {
     ///
     /// See the [toggle transform](https://vega.github.io/vega-lite/docs/toggle.html)
     /// documentation for more information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub toggle: Option<Translate>,
     /// An interval selection also adds a rectangle mark to depict the
     /// extents of the interval. The `mark` property can be used to customize the
     /// appearance of the mark.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mark: Option<BrushConfig>,
     /// When truthy, allows a user to interactively move an interval selection
     /// back-and-forth. Can be `true`, `false` (to disable panning), or a
@@ -6781,6 +7729,7 @@ pub struct SelectionDef {
     /// __Default value:__ `true`, which corresponds to
     /// `[mousedown, window:mouseup] > window:mousemove!` which corresponds to
     /// clicks and dragging within an interval selection to reposition it.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub translate: Option<Translate>,
     /// When truthy, allows a user to interactively resize an interval selection.
     /// Can be `true`, `false` (to disable zooming), or a [Vega event stream
@@ -6789,11 +7738,13 @@ pub struct SelectionDef {
     ///
     ///
     /// __Default value:__ `true`, which corresponds to `wheel!`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zoom: Option<Translate>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TitleParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
     /// The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`. For
     /// example, with an orientation of top these anchor positions map to a left-, center-, or
@@ -6808,40 +7759,52 @@ pub struct TitleParams {
     /// customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and
     /// [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite
     /// views, `anchor` is always `"start"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub anchor: Option<TitleAnchor>,
     /// Angle in degrees of title text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub angle: Option<f64>,
     /// Vertical text baseline for title text. One of `"top"`, `"middle"`, `"bottom"`, or
     /// `"alphabetic"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub baseline: Option<TextBaseline>,
     /// Text color for title text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<String>,
     /// Font name for title text.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font: Option<String>,
     /// Font size in pixels for title text.
     ///
     /// __Default value:__ `10`.
     #[serde(rename = "fontSize")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_size: Option<f64>,
     /// Font weight for title text.
     /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
     /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
     #[serde(rename = "fontWeight")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<FontWeight>,
     /// The reference frame for the anchor position, one of `"bounds"` (to anchor relative to the
     /// full bounding box) or `"group"` (to anchor relative to the group width or height).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub frame: Option<TitleFrame>,
     /// The maximum allowed length in pixels of legend labels.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<f64>,
     /// The orthogonal offset in pixels by which to displace the title from its position along
     /// the edge of the chart.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<f64>,
     /// Default title orientation (`"top"`, `"bottom"`, `"left"`, or `"right"`)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orient: Option<LegendOrient>,
     /// A [mark style property](https://vega.github.io/vega-lite/docs/config.html#style) to apply
     /// to the title text mark.
     ///
     /// __Default value:__ `"group-title"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub style: Option<Style>,
     /// The title text.
     pub text: String,
@@ -6849,6 +7812,7 @@ pub struct TitleParams {
     /// mark and legend groups.
     ///
     /// __Default value:__ `0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub zindex: Option<f64>,
 }
 
@@ -6872,6 +7836,7 @@ pub struct Transform {
     /// predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate)
     ///
     /// 4) a logical operand that combines (1), (2), or (3).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<LogicalOperandPredicate>,
     /// The field for storing the computed formula value.
     ///
@@ -6896,27 +7861,35 @@ pub struct Transform {
     /// The output field names for the key and value properties produced by the fold transform.
     /// __Default value:__ `["key", "value"]`
     #[serde(rename = "as")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transform_as: Option<Style>,
     /// A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string. Use
     /// the variable `datum` to refer to the current data object.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub calculate: Option<String>,
     /// The default value to use if lookup fails.
     ///
     /// __Default value:__ `null`
     #[serde(rename = "default")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transform_default: Option<String>,
     /// Secondary data reference.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub from: Option<LookupData>,
     /// Key in primary data source.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lookup: Option<String>,
     /// An object indicating bin properties, or simply `true` for using default bin parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bin: Option<TransformBin>,
     /// The data field to bin.
     ///
     /// The data field to apply time unit.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     /// The timeUnit.
     #[serde(rename = "timeUnit")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_unit: Option<TimeUnit>,
     /// A frame specification as a two-element array used to control the window over which the
     /// specified method is applied. The array entries should either be a number indicating the
@@ -6939,6 +7912,7 @@ pub struct Transform {
     /// operations are not affected by this.
     ///
     /// __Default value:__:  `[null, 0]` (includes the current object and all preceding objects)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub frame: Option<Vec<Option<f64>>>,
     /// An optional array of fields by which to group the values.
     /// Imputation will then be performed on a per-group basis.
@@ -6950,12 +7924,14 @@ pub struct Transform {
     /// all data points will be in a single group.
     ///
     /// The data fields to group by.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub groupby: Option<Vec<String>>,
     /// The data field for which the missing values should be imputed.
     pub impute: Option<String>,
     /// A key field that uniquely identifies data objects within a group.
     /// Missing key values (those occurring in the data but not in the current group) will be
     /// imputed.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
     /// Defines the key values that should be considered for imputation.
     /// An array of key values or an object defining a [number
@@ -6967,15 +7943,19 @@ pub struct Transform {
     /// imputed, or vice versa.
     ///
     /// If there is no impute grouping, this property _must_ be specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub keyvals: Option<Keyvals>,
     /// The imputation method to use for the field value of imputed data objects.
     /// One of `value`, `mean`, `median`, `max` or `min`.
     ///
     /// __Default value:__  `"value"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<ImputeMethod>,
     /// The field value to use when the imputation `method` is `"value"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<serde_json::Value>,
     /// Array of objects that define fields to aggregate.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<Vec<AggregatedFieldDef>>,
     /// Indicates if the sliding window frame should ignore peer values. (Peer values are those
     /// considered identical by the sort criteria). The default is false, causing the window
@@ -6986,6 +7966,7 @@ pub struct Transform {
     ///
     /// __Default value:__ `false`
     #[serde(rename = "ignorePeers")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_peers: Option<bool>,
     /// A sort field definition for sorting data objects within a window. If two data objects are
     /// considered equal by the comparator, they are considered “peer” values of equal rank. If
@@ -6994,25 +7975,32 @@ pub struct Transform {
     /// treated as if set to `true`).
     ///
     /// Field that determines the order of leaves in the stacked charts.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<Vec<SortField>>,
     /// The definition of the fields in the window, and what calculations to use.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub window: Option<Vec<WindowFieldDef>>,
     /// Mode for stacking marks.
     /// __Default value:__ `"zero"`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<StackOffset>,
     /// The field which is stacked.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stack: Option<String>,
     /// An array of one or more data fields containing arrays to flatten.
     /// If multiple fields are specified, their array values should have a parallel structure,
     /// ideally with the same length.
     /// If the lengths of parallel arrays do not match,
     /// the longest array will be used with `null` values added for missing entries.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flatten: Option<Vec<String>>,
     /// An array of data fields indicating the properties to fold.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fold: Option<Vec<String>>,
     /// The maximum number of data objects to include in the sample.
     ///
     /// __Default value:__ `1000`
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sample: Option<f64>,
 }
 
@@ -7023,6 +8011,7 @@ pub struct AggregatedFieldDef {
     pub aggregated_field_def_as: String,
     /// The data field for which to compute aggregate function. This is required for all
     /// aggregation operations except `"count"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     /// The aggregation operations to apply to the fields, such as sum, average or count.
     /// See the [full list of supported aggregation
@@ -7038,6 +8027,7 @@ pub struct LookupData {
     pub data: Data,
     /// Fields in foreign data to lookup.
     /// If not specified, the entire object is queried.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fields: Option<Vec<String>>,
     /// Key in data to lookup.
     pub key: String,
@@ -7049,6 +8039,7 @@ pub struct SortField {
     /// The name of the field to sort.
     pub field: String,
     /// Whether to sort the field in ascending or descending order.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<VgComparatorOrder>,
 }
 
@@ -7060,6 +8051,7 @@ pub struct WindowFieldDef {
     /// The data field for which to compute the aggregate or window function. This can be omitted
     /// for window functions that do not operate over a field such as `count`, `rank`,
     /// `dense_rank`.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     /// The window or aggregation operations to apply within a window, including `rank`, `lead`,
     /// `sum`, `average` or `count`. See the list of all supported operations
@@ -7070,6 +8062,7 @@ pub struct WindowFieldDef {
     ///
     /// See the list of all supported operations and their parameters
     /// [here](https://vega.github.io/vega-lite/docs/transforms/window.html).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub param: Option<f64>,
 }
 
@@ -7078,14 +8071,18 @@ pub struct WindowFieldDef {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Repeat {
     /// Horizontal repeated views.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<Vec<String>>,
     /// Vertical repeated views.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RowColNumber {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub row: Option<f64>,
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,7 +14,7 @@
 extern crate serde_json;
 use std::collections::HashMap;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Vegalite {
     /// URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you
     /// have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`.
@@ -241,13 +241,13 @@ pub struct Vegalite {
     pub hconcat: Option<Vec<Spec>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RowColVgLayoutAlign {
     pub column: Option<VgLayoutAlign>,
     pub row: Option<VgLayoutAlign>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AutoSizeParams {
     /// Determines how size calculation should be performed, one of `"content"` or `"padding"`.
     /// The default setting (`"content"`) interprets the width and height settings as the data
@@ -274,7 +274,7 @@ pub struct AutoSizeParams {
     pub auto_size_params_type: Option<AutosizeType>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RowColBoolean {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<bool>,
@@ -284,7 +284,7 @@ pub struct RowColBoolean {
 
 /// Vega-Lite configuration object.  This property can only be defined at the top-level of a
 /// specification.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     /// Area-Specific Config
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -483,7 +483,7 @@ pub struct Config {
 }
 
 /// Area-Specific Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AreaConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     pub align: Option<Align>,
@@ -690,7 +690,7 @@ pub struct AreaConfig {
     pub tooltip: Option<Tooltip>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OverlayMarkDef {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     pub align: Option<Align>,
@@ -900,7 +900,7 @@ pub struct OverlayMarkDef {
     pub y_offset: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TooltipContent {
     pub content: Content,
 }
@@ -923,7 +923,7 @@ pub struct TooltipContent {
 /// X-axis specific config.
 ///
 /// Y-axis specific config.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AxisConfig {
     /// An interpolation fraction indicating where, for `band` scales, axis ticks should be
     /// positioned. A value of `0` places ticks at the left edge of their bands. A value of `0.5`
@@ -1148,7 +1148,7 @@ pub struct AxisConfig {
 }
 
 /// Bar-Specific Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BarConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     pub align: Option<Align>,
@@ -1348,7 +1348,7 @@ pub struct BarConfig {
 }
 
 /// Box Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BoxPlotConfig {
     #[serde(rename = "box")]
     pub box_plot_config_box: Option<BooleanOrMarkConfig>,
@@ -1381,7 +1381,7 @@ pub struct BoxPlotConfig {
 /// Rule-Specific Config
 ///
 /// Square-Specific Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MarkConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1602,7 +1602,7 @@ pub struct MarkConfig {
 }
 
 /// ErrorBand Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ErrorBandConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub band: Option<BooleanOrMarkConfig>,
@@ -1645,7 +1645,7 @@ pub struct ErrorBandConfig {
 }
 
 /// ErrorBar Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ErrorBarConfig {
     /// The extent of the rule. Available options include:
     /// - `"ci"`: Extend the rule to the confidence interval of the mean.
@@ -1668,7 +1668,7 @@ pub struct ErrorBarConfig {
 /// [header](https://vega.github.io/vega-lite/docs/header.html). For a full list of header
 /// configuration options, please see the [corresponding section of in the header
 /// documentation](https://vega.github.io/vega-lite/docs/header.html#config).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HeaderConfig {
     /// The rotation angle of the header labels.
     ///
@@ -1768,7 +1768,7 @@ pub struct HeaderConfig {
 /// [legends](https://vega.github.io/vega-lite/docs/legend.html). For a full list of legend
 /// configuration options, please see the [corresponding section of in the legend
 /// documentation](https://vega.github.io/vega-lite/docs/legend.html#config).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LegendConfig {
     /// The height in pixels to clip symbol legend entries and limit their size.
     #[serde(rename = "clipHeight")]
@@ -2057,7 +2057,7 @@ pub struct LegendConfig {
 /// Line-Specific Config
 ///
 /// Trail-Specific Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LineConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2292,7 +2292,7 @@ pub struct LineConfig {
     pub tooltip: Option<Tooltip>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PaddingClass {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bottom: Option<f64>,
@@ -2316,7 +2316,7 @@ pub struct PaddingClass {
 /// and to `latitude` and `"longitude"` channels for other marks.
 ///
 /// An object defining properties of the geographic projection shared by underlying layers.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Projection {
     /// Sets the projection’s center to the specified center, a two-element array of longitude
     /// and latitude in degrees.
@@ -2381,7 +2381,7 @@ pub struct Projection {
     pub projection_type: Option<VgProjectionType>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VgScheme {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub count: Option<f64>,
@@ -2397,7 +2397,7 @@ pub struct VgScheme {
 /// [scales](https://vega.github.io/vega-lite/docs/scale.html). For a full list of scale
 /// configuration options, please see the [corresponding section of the scale
 /// documentation](https://vega.github.io/vega-lite/docs/scale.html#config).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScaleConfig {
     /// Default inner padding for `x` and `y` band-ordinal scales.
     ///
@@ -2539,7 +2539,7 @@ pub struct ScaleConfig {
 }
 
 /// An object hash for defining default properties for each type of selections.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SelectionConfig {
     /// The default definition for an
     /// [`interval`](https://vega.github.io/vega-lite/docs/selection.html#type) selection. All
@@ -2577,7 +2577,7 @@ pub struct SelectionConfig {
 ///
 /// For instance, setting `interval` to `{"translate": false}` disables the ability to move
 /// interval selections by default.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IntervalSelectionConfig {
     /// Establishes a two-way binding between the interval selection and the scales
     /// used within the same view. This allows a user to interactively pan and
@@ -2636,7 +2636,7 @@ pub struct IntervalSelectionConfig {
 /// An interval selection also adds a rectangle mark to depict the
 /// extents of the interval. The `mark` property can be used to customize the
 /// appearance of the mark.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BrushConfig {
     /// The fill color of the interval mark.
     ///
@@ -2680,7 +2680,7 @@ pub struct BrushConfig {
 ///
 /// For instance, setting `multi` to `{"toggle": "event.altKey"}` adds additional values to
 /// multi selections when clicking with the alt-key pressed by default.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MultiSelectionConfig {
     /// By default, all data values are considered to lie within an empty selection.
     /// When set to `none`, empty selections contain no data values.
@@ -2732,7 +2732,7 @@ pub struct MultiSelectionConfig {
 ///
 /// For instance, setting `single` to `{"on": "dblclick"}` populates single selections on
 /// double-click by default.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SingleSelectionConfig {
     /// Establish a two-way binding between a single selection and input elements
     /// (also known as dynamic query widgets). A binding takes the form of
@@ -2775,7 +2775,7 @@ pub struct SingleSelectionConfig {
     pub resolve: Option<SelectionResolution>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VgBinding {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub element: Option<String>,
@@ -2790,7 +2790,7 @@ pub struct VgBinding {
     pub step: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VgMarkConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2981,7 +2981,7 @@ pub struct VgMarkConfig {
 }
 
 /// Text-Specific Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TextConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3206,7 +3206,7 @@ pub struct TextConfig {
 }
 
 /// Tick-Specific Config
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TickConfig {
     /// The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3441,7 +3441,7 @@ pub struct TickConfig {
 /// [titles](https://vega.github.io/vega-lite/docs/title.html). For a full list of title
 /// configuration options, please see the [corresponding section of the title
 /// documentation](https://vega.github.io/vega-lite/docs/title.html#config).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VgTitleConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
@@ -3493,7 +3493,7 @@ pub struct VgTitleConfig {
 
 /// Default properties for [single view
 /// plots](https://vega.github.io/vega-lite/docs/spec.html#single).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ViewConfig {
     /// Whether the view should be clipped.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3568,7 +3568,7 @@ pub struct ViewConfig {
 /// An object describing the data source
 ///
 /// Secondary data source to lookup in.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Data {
     /// An object that specifies the format for parsing the data.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3589,7 +3589,7 @@ pub struct Data {
 }
 
 /// An object that specifies the format for parsing the data.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DataFormat {
     /// If set to `null`, disable type inference based on the spec and only use type inference
     /// based on the data.
@@ -3646,7 +3646,7 @@ pub struct DataFormat {
 ///
 /// A shared key-value mapping between encoding channels and definition of fields in the
 /// underlying layers.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Encoding {
     /// Color of the marks – either fill or stroke color based on  the `filled` property of mark
     /// definition.
@@ -3834,7 +3834,7 @@ pub struct Encoding {
 /// condition: {field: ...} | {value: ...},
 /// value: ...,
 /// }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MarkPropDefWithCondition {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -3966,7 +3966,7 @@ pub struct MarkPropDefWithCondition {
 }
 
 /// Binning properties or boolean flag for determining whether to bin data or not.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BinParams {
     /// A value in the binned domain at which to anchor the bins, shifting the bin boundaries if
     /// necessary to ensure that a boundary aligns with the anchor value.
@@ -4013,7 +4013,7 @@ pub struct BinParams {
     pub steps: Option<Vec<f64>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConditionalValueDef {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
@@ -4027,7 +4027,7 @@ pub struct ConditionalValueDef {
     pub selection: Option<SelectionOperand>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Selection {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub not: Option<Box<SelectionOperand>>,
@@ -4037,7 +4037,7 @@ pub struct Selection {
     pub or: Option<Vec<SelectionOperand>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Predicate {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub not: Option<Box<LogicalOperandPredicate>>,
@@ -4089,7 +4089,7 @@ pub struct Predicate {
 /// If both month and quarter are provided, month has higher precedence.
 /// `day` cannot be combined with other date.
 /// We accept string for month and day names.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DateTime {
     /// Integer value representing the date from 1-31.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4130,7 +4130,7 @@ pub struct DateTime {
     pub year: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConditionalPredicateMarkPropFieldDefClass {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
@@ -4260,13 +4260,13 @@ pub struct ConditionalPredicateMarkPropFieldDefClass {
 }
 
 /// Reference to a repeated value.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RepeatRef {
     pub repeat: SingleDefChannel,
 }
 
 /// Properties of a legend or boolean flag for determining whether to show it.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Legend {
     /// The height in pixels to clip symbol legend entries and limit their size.
     #[serde(rename = "clipHeight")]
@@ -4563,7 +4563,7 @@ pub struct Legend {
     pub zindex: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Scale {
     /// The logarithm base of the `log` scale (default `10`).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4787,7 +4787,7 @@ pub struct Scale {
     pub zero: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DomainClass {
     /// The field name to extract selected values for, when a selection is
     /// [projected](https://vega.github.io/vega-lite/docs/project.html)
@@ -4803,7 +4803,7 @@ pub struct DomainClass {
     pub encoding: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScaleInterpolateParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gamma: Option<f64>,
@@ -4811,13 +4811,13 @@ pub struct ScaleInterpolateParams {
     pub scale_interpolate_params_type: ScaleInterpolateParamsType,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NiceClass {
     pub interval: String,
     pub step: f64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SchemeParams {
     /// The number of colors to use in the scheme. This can be useful for scale types such as
     /// `"quantize"`, which use the length of the scale range to determine the number of discrete
@@ -4837,7 +4837,7 @@ pub struct SchemeParams {
 }
 
 /// A sort definition for sorting a discrete scale in an encoding field definition.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EncodingSortField {
     /// The data [field](https://vega.github.io/vega-lite/docs/field.html) to sort by.
     ///
@@ -4862,7 +4862,7 @@ pub struct EncodingSortField {
 /// Horizontal facets for trellis plots.
 ///
 /// Vertical facets for trellis plots.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FacetFieldDef {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -4968,7 +4968,7 @@ pub struct FacetFieldDef {
 /// An object defining properties of a facet's header.
 ///
 /// Headers of row / column channels for faceted plots.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Header {
     /// The formatting pattern for labels. This is D3's [number format
     /// pattern](https://github.com/d3/d3-format#locale_format) for quantitative fields and D3's
@@ -5114,7 +5114,7 @@ pub struct Header {
 ///
 /// Longitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`,
 /// and  `"rule"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FieldDef {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5204,7 +5204,7 @@ pub struct FieldDef {
 /// condition: {field: ...} | {value: ...},
 /// value: ...,
 /// }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DefWithCondition {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5293,7 +5293,7 @@ pub struct DefWithCondition {
     pub value: Option<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConditionalPredicateFieldDefClass {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
@@ -5380,7 +5380,7 @@ pub struct ConditionalPredicateFieldDefClass {
     pub conditional_def_type: Option<Type>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OrderFieldDef {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5460,7 +5460,7 @@ pub struct OrderFieldDef {
 }
 
 /// Definition object for a constant value of an encoding channel.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OrderFieldDefClass {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5558,7 +5558,7 @@ pub struct OrderFieldDefClass {
 /// condition: {field: ...} | {value: ...},
 /// value: ...,
 /// }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TextClass {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5651,7 +5651,7 @@ pub struct TextClass {
     pub value: Option<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ConditionalPredicateTextFieldDefClass {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<LogicalOperandPredicate>,
@@ -5742,7 +5742,7 @@ pub struct ConditionalPredicateTextFieldDefClass {
     pub conditional_def_type: Option<Type>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TextFieldDef {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5834,7 +5834,7 @@ pub struct TextFieldDef {
 /// condition: {field: ...} | {value: ...},
 /// value: ...,
 /// }
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TextDefWithCondition {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -5932,7 +5932,7 @@ pub struct TextDefWithCondition {
 /// Y coordinates of the marks, or height of vertical `"bar"` and `"area"`.
 ///
 /// Definition object for a constant value of an encoding channel.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct XClass {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -6085,7 +6085,7 @@ pub struct XClass {
     pub value: Option<Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Axis {
     /// An interpolation fraction indicating where, for `band` scales, axis ticks should be
     /// positioned. A value of `0` places ticks at the left edge of their bands. A value of `0.5`
@@ -6438,7 +6438,7 @@ pub struct Axis {
 /// Operation.
 /// The field of the `color` channel if specified is used as `groupby` of the `Impute`
 /// Operation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ImputeParams {
     /// A frame specification as a two-element array used to control the window over which the
     /// specified method is applied. The array entries should either be a number indicating the
@@ -6473,7 +6473,7 @@ pub struct ImputeParams {
     pub value: Option<serde_json::Value>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ImputeSequence {
     /// The starting value of the sequence.
     /// __Default value:__ `0`
@@ -6508,7 +6508,7 @@ pub struct ImputeSequence {
 /// and  `"rule"`.
 ///
 /// Definition object for a constant value of an encoding channel.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct X2Class {
     /// Aggregation function for the field
     /// (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).
@@ -6591,7 +6591,7 @@ pub struct X2Class {
 
 /// An object that describes mappings between `row` and `column` channels and their field
 /// definitions.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FacetMapping {
     /// Horizontal facets for trellis plots.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -6606,7 +6606,7 @@ pub struct FacetMapping {
 /// Layer Spec with encoding and projection
 ///
 /// Unit spec that can have a composite mark and row or column channels.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SpecClass {
     /// An object describing the data source
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -6793,7 +6793,7 @@ pub struct SpecClass {
 /// Unit spec that can have a composite mark and row or column channels.
 ///
 /// Layer Spec with encoding and projection
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Spec {
     /// An object describing the data source
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -6980,7 +6980,7 @@ pub struct Spec {
 /// Layer Spec with encoding and projection
 ///
 /// Unit spec that can have a composite mark.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LayerSpec {
     /// An object describing the data source
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7089,7 +7089,7 @@ pub struct LayerSpec {
 /// underlying layers.
 ///
 /// A key-value mapping between encoding channels and definition of fields.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LayerEncoding {
     /// Color of the marks – either fill or stroke color based on  the `filled` property of mark
     /// definition.
@@ -7208,7 +7208,7 @@ pub struct LayerEncoding {
     pub y2: Option<X2Class>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BoxPlotDefClass {
     #[serde(rename = "box")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7604,7 +7604,7 @@ pub struct BoxPlotDefClass {
 /// Scale, axis, and legend resolutions for vertically concatenated charts.
 ///
 /// Scale, axis, and legend resolutions for horizontally concatenated charts.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Resolve {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub axis: Option<AxisResolveMap>,
@@ -7614,7 +7614,7 @@ pub struct Resolve {
     pub scale: Option<ScaleResolveMap>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AxisResolveMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub x: Option<ResolveMode>,
@@ -7622,7 +7622,7 @@ pub struct AxisResolveMap {
     pub y: Option<ResolveMode>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LegendResolveMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ResolveMode>,
@@ -7638,7 +7638,7 @@ pub struct LegendResolveMap {
     pub stroke: Option<ResolveMode>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ScaleResolveMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ResolveMode>,
@@ -7658,7 +7658,7 @@ pub struct ScaleResolveMap {
     pub y: Option<ResolveMode>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SelectionDef {
     /// Establish a two-way binding between a single selection and input elements
     /// (also known as dynamic query widgets). A binding takes the form of
@@ -7742,7 +7742,7 @@ pub struct SelectionDef {
     pub zoom: Option<Translate>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TitleParams {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub align: Option<Align>,
@@ -7816,7 +7816,7 @@ pub struct TitleParams {
     pub zindex: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Transform {
     /// The `filter` property must be one of the predicate definitions:
     ///
@@ -8004,7 +8004,7 @@ pub struct Transform {
     pub sample: Option<f64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AggregatedFieldDef {
     /// The output field names to use for each aggregated field.
     #[serde(rename = "as")]
@@ -8021,7 +8021,7 @@ pub struct AggregatedFieldDef {
 }
 
 /// Secondary data reference.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LookupData {
     /// Secondary data source to lookup in.
     pub data: Data,
@@ -8034,7 +8034,7 @@ pub struct LookupData {
 }
 
 /// A sort definition for transform
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SortField {
     /// The name of the field to sort.
     pub field: String,
@@ -8043,7 +8043,7 @@ pub struct SortField {
     pub order: Option<VgComparatorOrder>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WindowFieldDef {
     /// The output name for the window operation.
     #[serde(rename = "as")]
@@ -8068,7 +8068,7 @@ pub struct WindowFieldDef {
 
 /// An object that describes what fields should be repeated into views that are laid out as a
 /// `row` or `column`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Repeat {
     /// Horizontal repeated views.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -8078,7 +8078,7 @@ pub struct Repeat {
     pub row: Option<Vec<String>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RowColNumber {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub column: Option<f64>,
@@ -8101,7 +8101,7 @@ pub struct RowColNumber {
 /// used to supply different alignments for rows and columns.
 ///
 /// __Default value:__ `"all"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AlignUnion {
     Enum(VgLayoutAlign),
@@ -8115,14 +8115,14 @@ pub enum AlignUnion {
 /// `"fit"` is only supported for single and layered views that don't use `rangeStep`.
 ///
 /// __Default value__: `pad`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Autosize {
     AutoSizeParams(AutoSizeParams),
     Enum(AutosizeType),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Center {
     Bool(bool),
@@ -8152,14 +8152,14 @@ pub enum Center {
 /// Font weight for title text.
 /// This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`,
 /// ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum FontWeight {
     Double(f64),
     Enum(FontWeightEnum),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Line {
     Bool(bool),
@@ -8195,21 +8195,21 @@ pub enum Line {
 /// two elements denoting the name for the fields for stack start and stack end
 /// respectively.
 /// If a single string(eg."val") is provided, the end field will be "val_end".
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Style {
     String(String),
     StringArray(Vec<String>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Tooltip {
     String(String),
     TooltipContent(TooltipContent),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PointUnion {
     Bool(bool),
@@ -8234,7 +8234,7 @@ pub enum PointUnion {
 /// can sometimes help the labels better visually group with corresponding axis ticks.
 ///
 /// __Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Label {
     Bool(bool),
@@ -8266,14 +8266,14 @@ pub enum Label {
 /// better for log-scaled axes).
 ///
 /// __Default value:__ `true`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LabelOverlap {
     Bool(bool),
     Enum(LabelOverlapEnum),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BooleanOrMarkConfig {
     Bool(bool),
@@ -8287,7 +8287,7 @@ pub enum BooleanOrMarkConfig {
 /// whisker and subtracted from the first quartile to get the lower whisker.
 ///
 /// __Default value:__ `1.5`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BoxplotExtent {
     Double(f64),
@@ -8300,21 +8300,21 @@ pub enum BoxplotExtent {
 /// "bottom": 5}` to specify padding for each side of the visualization.
 ///
 /// __Default value__: `5`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Padding {
     Double(f64),
     PaddingClass(PaddingClass),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RangeValue {
     UnionArray(Vec<RangeElement>),
     VgScheme(VgScheme),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum RangeElement {
     Double(f64),
@@ -8347,14 +8347,14 @@ pub enum RangeElement {
 ///
 /// See the [toggle transform](https://vega.github.io/vega-lite/docs/toggle.html)
 /// documentation for more information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Translate {
     Bool(bool),
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BindValue {
     Double(f64),
@@ -8367,7 +8367,7 @@ pub enum BindValue {
 /// an object, or a string.
 /// Arrays of primitive values are ingested as objects with a `data` property. Strings are
 /// parsed according to the specified format type.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DataInlineDataset {
     AnythingMap(HashMap<String, Option<serde_json::Value>>),
@@ -8375,7 +8375,7 @@ pub enum DataInlineDataset {
     UnionArray(Vec<InlineDataset>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlineDataset {
     AnythingMap(HashMap<String, Option<serde_json::Value>>),
@@ -8388,7 +8388,7 @@ pub enum InlineDataset {
 /// an object, or a string.
 /// Arrays of primitive values are ingested as objects with a `data` property. Strings are
 /// parsed according to the specified format type.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InlineDatasetValue {
     AnythingMap(HashMap<String, Option<serde_json::Value>>),
@@ -8396,7 +8396,7 @@ pub enum InlineDatasetValue {
     UnionArray(Vec<InlineDataset>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Bin {
     BinParams(BinParams),
@@ -8404,7 +8404,7 @@ pub enum Bin {
     Enum(BinEnum),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ColorCondition {
     ConditionalPredicateMarkPropFieldDefClass(ConditionalPredicateMarkPropFieldDefClass),
@@ -8415,7 +8415,7 @@ pub enum ColorCondition {
 ///
 /// A [selection name](https://vega.github.io/vega-lite/docs/selection.html), or a series of
 /// [composed selections](https://vega.github.io/vega-lite/docs/selection.html#compose).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SelectionOperand {
     Selection(Selection),
@@ -8440,14 +8440,14 @@ pub enum SelectionOperand {
 /// predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate)
 ///
 /// 4) a logical operand that combines (1), (2), or (3).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum LogicalOperandPredicate {
     Predicate(Predicate),
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum EqualUnion {
     Bool(bool),
@@ -8461,7 +8461,7 @@ pub enum EqualUnion {
 /// case-insensitive, 3-character short day name (e.g., `"Mon"`).   <br/> **Warning:** A
 /// DateTime definition object with `day`** should not be combined with `year`, `quarter`,
 /// `month`, or `date`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Day {
     Double(f64),
@@ -8471,14 +8471,14 @@ pub enum Day {
 /// One of: (1) integer value representing the month from `1`-`12`. `1` represents January;
 /// (2) case-insensitive month name (e.g., `"January"`);  (3) case-insensitive, 3-character
 /// short month name (e.g., `"Jan"`).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Month {
     Double(f64),
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Lt {
     DateTime(DateTime),
@@ -8486,7 +8486,7 @@ pub enum Lt {
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SortElement {
     Bool(bool),
@@ -8495,7 +8495,7 @@ pub enum SortElement {
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PurpleRange {
     DateTime(DateTime),
@@ -8506,7 +8506,7 @@ pub enum PurpleRange {
 /// `0` to `1` for opacity).
 ///
 /// A constant value in visual domain.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Value {
     Bool(bool),
@@ -8514,7 +8514,7 @@ pub enum Value {
     String(String),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Field {
     RepeatRef(RepeatRef),
@@ -8540,7 +8540,7 @@ pub enum Field {
 /// The `selection` property can be used to [interactively
 /// determine](https://vega.github.io/vega-lite/docs/selection.html#scale-domains) the scale
 /// domain.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DomainUnion {
     DomainClass(DomainClass),
@@ -8563,7 +8563,7 @@ pub enum DomainUnion {
 /// interpolator.  Since Vega-Lite uses sequential scales for quantitative fields by default,
 /// you have to set the scale `type` to other quantitative scale type such as `"linear"` to
 /// customize `interpolate`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum InterpolateUnion {
     Enum(ScaleInterpolate),
@@ -8589,7 +8589,7 @@ pub enum InterpolateUnion {
 /// snap to quarter (Jan, Apr, Jul, Oct) boundaries.
 ///
 /// __Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum NiceUnion {
     Bool(bool),
@@ -8625,7 +8625,7 @@ pub enum NiceUnion {
 /// [size](https://vega.github.io/vega-lite/docs/size.html) (`width` and `height`) or via
 /// [range steps and paddings properties](#range-step) for [band](#band) and [point](#point)
 /// scales.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ScaleRange {
     String(String),
@@ -8645,7 +8645,7 @@ pub enum ScaleRange {
 ///
 /// For the full list of supported schemes, please refer to the [Vega
 /// Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Scheme {
     SchemeParams(SchemeParams),
@@ -8674,7 +8674,7 @@ pub enum Scheme {
 /// __Default value:__ `"ascending"`
 ///
 /// __Note:__ `null` is not supported for `row` and `column`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Sort {
     EncodingSortField(EncodingSortField),
@@ -8682,42 +8682,42 @@ pub enum Sort {
     UnionArray(Vec<SortElement>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Detail {
     FieldDef(FieldDef),
     FieldDefArray(Vec<FieldDef>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum HrefCondition {
     ConditionalPredicateFieldDefClass(ConditionalPredicateFieldDefClass),
     ConditionalValueDefArray(Vec<ConditionalValueDef>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Order {
     OrderFieldDefArray(Vec<OrderFieldDef>),
     OrderFieldDefClass(OrderFieldDefClass),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TextCondition {
     ConditionalPredicateTextFieldDefClass(ConditionalPredicateTextFieldDefClass),
     ConditionalValueDefArray(Vec<ConditionalValueDef>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum EncodingTooltip {
     TextDefWithCondition(TextDefWithCondition),
     TextFieldDefArray(Vec<TextFieldDef>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Keyvals {
     AnythingArray(Vec<Option<serde_json::Value>>),
@@ -8728,28 +8728,28 @@ pub enum Keyvals {
 /// `"line"`,
 /// `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition
 /// object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum AnyMark {
     BoxPlotDefClass(BoxPlotDefClass),
     Enum(BoxPlot),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BoxPlotDefExtent {
     Double(f64),
     Enum(ExtentExtent),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum SelectionDefBind {
     Enum(BindEnum),
     UnionMap(HashMap<String, BindValue>),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Title {
     String(String),
@@ -8757,14 +8757,14 @@ pub enum Title {
 }
 
 /// An object indicating bin properties, or simply `true` for using default bin parameters.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TransformBin {
     BinParams(BinParams),
     Bool(bool),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Spacing {
     Double(f64),
@@ -8779,7 +8779,7 @@ pub enum Spacing {
 ///
 /// By default, all data values are considered to lie within an empty selection.
 /// When set to `none`, empty selections contain no data values.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum VgLayoutAlign {
     #[serde(rename = "all")]
     All,
@@ -8794,7 +8794,7 @@ pub enum VgLayoutAlign {
 /// descriptions of each.
 ///
 /// __Default value__: `"pad"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AutosizeType {
     #[serde(rename = "fit")]
     Fit,
@@ -8811,7 +8811,7 @@ pub enum AutosizeType {
 /// width and height settings indicate the **total** intended size of the view.
 ///
 /// __Default value__: `"content"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Contains {
     #[serde(rename = "content")]
     Content,
@@ -8829,7 +8829,7 @@ pub enum Contains {
 /// or legends into a uniform grid structure.
 ///
 /// __Default value:__ `"full"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Bounds {
     #[serde(rename = "flush")]
     Flush,
@@ -8849,7 +8849,7 @@ pub enum Bounds {
 /// Horizontal text alignment for legend titles.
 ///
 /// __Default value:__ `"left"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Align {
     #[serde(rename = "center")]
     Center,
@@ -8883,7 +8883,7 @@ pub enum Align {
 ///
 /// Vertical text baseline for title text. One of `"top"`, `"middle"`, `"bottom"`, or
 /// `"alphabetic"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TextBaseline {
     #[serde(rename = "alphabetic")]
     Alphabetic,
@@ -8897,7 +8897,7 @@ pub enum TextBaseline {
 
 /// The mouse cursor used over the mark. Any valid [CSS cursor
 /// type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Cursor {
     #[serde(rename = "alias")]
     Alias,
@@ -8977,7 +8977,7 @@ pub enum Cursor {
 /// This property determines on which side is truncated in response to the limit parameter.
 ///
 /// __Default value:__ `"ltr"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Dir {
     #[serde(rename = "ltr")]
     Ltr,
@@ -8986,7 +8986,7 @@ pub enum Dir {
 }
 
 /// The font style (e.g., `"italic"`).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FontStyle {
     #[serde(rename = "italic")]
     Italic,
@@ -8994,7 +8994,7 @@ pub enum FontStyle {
     Normal,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FontWeightEnum {
     #[serde(rename = "bold")]
     Bold,
@@ -9043,7 +9043,7 @@ pub enum FontWeightEnum {
 /// - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the
 /// spline.
 /// - `"monotone"`: cubic interpolation that preserves monotonicity in y.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Interpolate {
     #[serde(rename = "basis")]
     Basis,
@@ -9105,7 +9105,7 @@ pub enum Interpolate {
 /// __Default value:__ `"vertical"`.
 ///
 /// The direction of the legend, one of `"vertical"` (default) or `"horizontal"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Orient {
     #[serde(rename = "horizontal")]
     Horizontal,
@@ -9116,7 +9116,7 @@ pub enum Orient {
 /// The stroke cap for line ending style. One of `"butt"`, `"round"`, or `"square"`.
 ///
 /// __Default value:__ `"square"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum StrokeCap {
     #[serde(rename = "butt")]
     Butt,
@@ -9133,7 +9133,7 @@ pub enum StrokeCap {
 /// The stroke line join method. One of miter (default), round or bevel.
 ///
 /// __Default value:__ 'miter'
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum StrokeJoin {
     #[serde(rename = "bevel")]
     Bevel,
@@ -9143,7 +9143,7 @@ pub enum StrokeJoin {
     Round,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Content {
     #[serde(rename = "data")]
     Data,
@@ -9151,13 +9151,13 @@ pub enum Content {
     Encoding,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum PointEnum {
     #[serde(rename = "transparent")]
     Transparent,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LabelOverlapEnum {
     #[serde(rename = "greedy")]
     Greedy,
@@ -9165,7 +9165,7 @@ pub enum LabelOverlapEnum {
     Parity,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ExtentEnum {
     #[serde(rename = "min-max")]
     MinMax,
@@ -9190,7 +9190,7 @@ pub enum ExtentEnum {
 /// - `"iqr"`: Extend the rule to the q1 and q3.
 ///
 /// __Default value:__ `"stderr"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ErrorbandExtent {
     #[serde(rename = "ci")]
     Ci,
@@ -9209,7 +9209,7 @@ pub enum ErrorbandExtent {
 /// "SUM(field)", "YEARMONTH(date)", "BIN(field)").
 /// - `"plain"` - displays only the field name without functions (e.g., "field", "date",
 /// "field").
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FieldTitle {
     #[serde(rename = "functional")]
     Functional,
@@ -9219,7 +9219,7 @@ pub enum FieldTitle {
     Verbal,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum InvalidValues {
     #[serde(rename = "filter")]
     Filter,
@@ -9238,7 +9238,7 @@ pub enum InvalidValues {
 /// the right edge of the chart).
 ///
 /// __Default value:__ `"bottom"` for x-axes and `"left"` for y-axes.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LegendOrient {
     #[serde(rename = "bottom")]
     Bottom,
@@ -9266,7 +9266,7 @@ pub enum LegendOrient {
 /// documentation](https://vega.github.io/vega-lite/docs/projection.html#projection-types).
 ///
 /// __Default value:__ `mercator`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum VgProjectionType {
     #[serde(rename = "albers")]
     Albers,
@@ -9299,13 +9299,13 @@ pub enum VgProjectionType {
 /// Establishes a two-way binding between the interval selection and the scales
 /// used within the same view. This allows a user to interactively pan and
 /// zoom the view.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum BindEnum {
     #[serde(rename = "scales")]
     Scales,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SingleDefChannel {
     #[serde(rename = "color")]
     Color,
@@ -9352,7 +9352,7 @@ pub enum SingleDefChannel {
 /// With layered and multi-view displays, a strategy that determines how
 /// selections' data queries are resolved when applied in a filter transform,
 /// conditional encoding rule, or scale domain.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SelectionResolution {
     #[serde(rename = "global")]
     Global,
@@ -9366,7 +9366,7 @@ pub enum SelectionResolution {
 ///
 /// Mode for stacking marks.
 /// __Default value:__ `"zero"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum StackOffset {
     #[serde(rename = "center")]
     Center,
@@ -9393,7 +9393,7 @@ pub enum StackOffset {
 /// customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and
 /// [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite
 /// views, `anchor` is always `"start"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TitleAnchor {
     #[serde(rename = "end")]
     End,
@@ -9405,7 +9405,7 @@ pub enum TitleAnchor {
 
 /// The reference frame for the anchor position, one of `"bounds"` (to anchor relative to the
 /// full bounding box) or `"group"` (to anchor relative to the group width or height).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TitleFrame {
     #[serde(rename = "bounds")]
     Bounds,
@@ -9416,7 +9416,7 @@ pub enum TitleFrame {
 /// Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
 /// The default format type is determined by the extension of the file URL.
 /// If no extension is detected, `"json"` will be used by default.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DataFormatType {
     #[serde(rename = "csv")]
     Csv,
@@ -9448,7 +9448,7 @@ pub enum DataFormatType {
 /// See the [full list of supported aggregation
 /// operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops)
 /// for more information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AggregateOp {
     #[serde(rename = "argmax")]
     Argmax,
@@ -9496,7 +9496,7 @@ pub enum AggregateOp {
     Variancep,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum BinEnum {
     #[serde(rename = "binned")]
     Binned,
@@ -9511,7 +9511,7 @@ pub enum BinEnum {
 /// __Default value:__ `undefined` (None)
 ///
 /// The timeUnit.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum TimeUnit {
     #[serde(rename = "date")]
     Date,
@@ -9610,7 +9610,7 @@ pub enum TimeUnit {
 ///
 /// Constants and utilities for data type
 /// Data type based on level of measurement
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Type {
     #[serde(rename = "geojson")]
     Geojson,
@@ -9629,7 +9629,7 @@ pub enum Type {
 ///
 /// __Default value:__ `"gradient"` for non-binned quantitative fields and temporal fields;
 /// `"symbol"` otherwise.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum LegendType {
     #[serde(rename = "gradient")]
     Gradient,
@@ -9637,13 +9637,13 @@ pub enum LegendType {
     Symbol,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Domain {
     #[serde(rename = "unaggregated")]
     Unaggregated,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ScaleInterpolateParamsType {
     #[serde(rename = "cubehelix")]
     Cubehelix,
@@ -9653,7 +9653,7 @@ pub enum ScaleInterpolateParamsType {
     Rgb,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ScaleInterpolate {
     #[serde(rename = "cubehelix")]
     Cubehelix,
@@ -9673,7 +9673,7 @@ pub enum ScaleInterpolate {
     Rgb,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum NiceTime {
     #[serde(rename = "day")]
     Day,
@@ -9720,7 +9720,7 @@ pub enum NiceTime {
 ///
 /// __Default value:__ please see the [scale type
 /// table](https://vega.github.io/vega-lite/docs/scale.html#type).
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ScaleType {
     #[serde(rename = "band")]
     Band,
@@ -9755,7 +9755,7 @@ pub enum ScaleType {
 }
 
 /// Whether to sort the field in ascending or descending order.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum VgComparatorOrder {
     #[serde(rename = "ascending")]
     Ascending,
@@ -9767,7 +9767,7 @@ pub enum VgComparatorOrder {
 /// One of `value`, `mean`, `median`, `max` or `min`.
 ///
 /// __Default value:__  `"value"`
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ImputeMethod {
     #[serde(rename = "max")]
     Max,
@@ -9791,7 +9791,7 @@ pub enum ImputeMethod {
 /// The mark type.
 /// One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
 /// `"area"`, `"point"`, `"geoshape"`, `"rule"`, and `"text"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum BoxPlot {
     #[serde(rename = "area")]
     Area,
@@ -9844,7 +9844,7 @@ pub enum BoxPlot {
 /// - `"iqr"`: Extend the rule to the q1 and q3.
 ///
 /// __Default value:__ `"stderr"`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ExtentExtent {
     #[serde(rename = "ci")]
     Ci,
@@ -9858,7 +9858,7 @@ pub enum ExtentExtent {
     Stdev,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ResolveMode {
     #[serde(rename = "independent")]
     Independent,
@@ -9866,7 +9866,7 @@ pub enum ResolveMode {
     Shared,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SelectionDefType {
     #[serde(rename = "interval")]
     Interval,
@@ -9898,7 +9898,7 @@ pub enum SelectionDefType {
 /// See the [full list of supported aggregation
 /// operations](https://vega.github.io/vega-lite/docs/aggregate.html#ops)
 /// for more information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Op {
     #[serde(rename = "argmax")]
     Argmax,


### PR DESCRIPTION
It is important to be able to clone structures in order to use them as templates.
This patch make them all derive of Clone